### PR TITLE
Implement binary expressions in the new query engine

### DIFF
--- a/influxql/ast.go
+++ b/influxql/ast.go
@@ -250,6 +250,20 @@ func (*TimeLiteral) expr()     {}
 func (*VarRef) expr()          {}
 func (*Wildcard) expr()        {}
 
+// Literal represents a static literal.
+type Literal interface {
+	Expr
+	literal()
+}
+
+func (*BooleanLiteral) literal()  {}
+func (*DurationLiteral) literal() {}
+func (*nilLiteral) literal()      {}
+func (*NumberLiteral) literal()   {}
+func (*RegexLiteral) literal()    {}
+func (*StringLiteral) literal()   {}
+func (*TimeLiteral) literal()     {}
+
 // Source represents a source of data for a statement.
 type Source interface {
 	Node

--- a/influxql/call_iterator.go
+++ b/influxql/call_iterator.go
@@ -85,7 +85,7 @@ func newMinIterator(input Iterator, opt IteratorOptions) Iterator {
 // floatMinReduce returns the minimum value between prev & curr.
 func floatMinReduce(prev, curr *FloatPoint, opt *reduceOptions) (int64, float64, []interface{}) {
 	if prev == nil || curr.Value < prev.Value || (curr.Value == prev.Value && curr.Time < prev.Time) {
-		return curr.Time, curr.Value, curr.Aux
+		return opt.startTime, curr.Value, curr.Aux
 	}
 	return prev.Time, prev.Value, prev.Aux
 }
@@ -103,7 +103,7 @@ func newMaxIterator(input Iterator, opt IteratorOptions) Iterator {
 // floatMaxReduce returns the maximum value between prev & curr.
 func floatMaxReduce(prev, curr *FloatPoint, opt *reduceOptions) (int64, float64, []interface{}) {
 	if prev == nil || curr.Value > prev.Value || (curr.Value == prev.Value && curr.Time < prev.Time) {
-		return curr.Time, curr.Value, curr.Aux
+		return opt.startTime, curr.Value, curr.Aux
 	}
 	return prev.Time, prev.Value, prev.Aux
 }

--- a/influxql/iterator.gen.go.tmpl
+++ b/influxql/iterator.gen.go.tmpl
@@ -1,8 +1,9 @@
 package influxql
 
 import (
-	"math"
 	"container/heap"
+	"fmt"
+	"math"
 	"sort"
 	"sync"
 )
@@ -448,6 +449,24 @@ func (itr *{{.name}}AuxIterator) Close() error                  { return itr.inp
 func (itr *{{.name}}AuxIterator) Next() *{{.Name}}Point             { return <-itr.output }
 func (itr *{{.name}}AuxIterator) Iterator(name string) Iterator { return itr.fields.iterator(name) }
 
+func (itr *{{.name}}AuxIterator) CreateIterator(opt IteratorOptions) (Iterator, error) {
+	expr := opt.Expr
+	if expr == nil {
+		panic("unable to create an iterator with no expression from an aux iterator")
+	}
+
+	switch expr := expr.(type) {
+	case *VarRef:
+		return itr.fields.iterator(expr.Val), nil
+	default:
+		panic(fmt.Sprintf("invalid expression type for an aux iterator: %T", expr))
+	}
+}
+
+func (itr *{{.name}}AuxIterator) FieldDimensions(sources Sources) (fields, dimensions map[string]struct{}, err error) {
+	panic("not implemented")
+}
+
 func (itr *{{.name}}AuxIterator) stream() {
 	for {
 		// Read next point.
@@ -658,6 +677,54 @@ func (itr *{{.name}}ReduceSliceIterator) reduce() []{{.Name}}Point {
 
 // {{.name}}ReduceSliceFunc is the function called by a {{.Name}}Point slice reducer.
 type {{.name}}ReduceSliceFunc func(a []{{.Name}}Point, opt *reduceOptions) []{{.Name}}Point
+
+// {{.name}}ReduceIterator executes a function to modify an existing point for every
+// output of the input iterator.
+type {{.name}}TransformIterator struct {
+	input {{.Name}}Iterator
+	fn    {{.name}}TransformFunc
+}
+
+// Close closes the iterator and all child iterators.
+func (itr *{{.name}}TransformIterator) Close() error { return itr.input.Close() }
+
+// Next returns the minimum value for the next available interval.
+func (itr *{{.name}}TransformIterator) Next() *{{.Name}}Point {
+	p := itr.input.Next()
+	if p != nil {
+		p = itr.fn(p)
+	}
+	return p
+}
+
+// {{.name}}TransformFunc creates or modifies a point.
+// The point passed in may be modified and returned rather than allocating a
+// new point if possible.
+type {{.name}}TransformFunc func(p *{{.Name}}Point) *{{.Name}}Point
+
+// {{.name}}ReduceIterator executes a function to modify an existing point for every
+// output of the input iterator.
+type {{.name}}BoolTransformIterator struct {
+	input {{.Name}}Iterator
+	fn    {{.name}}BoolTransformFunc
+}
+
+// Close closes the iterator and all child iterators.
+func (itr *{{.name}}BoolTransformIterator) Close() error { return itr.input.Close() }
+
+// Next returns the minimum value for the next available interval.
+func (itr *{{.name}}BoolTransformIterator) Next() *BooleanPoint {
+	p := itr.input.Next()
+	if p != nil {
+		return itr.fn(p)
+	}
+	return nil
+}
+
+// {{.name}}BoolTransformFunc creates or modifies a point.
+// The point passed in may be modified and returned rather than allocating a
+// new point if possible.
+type {{.name}}BoolTransformFunc func(p *{{.Name}}Point) *BooleanPoint
 
 
 {{end}}

--- a/influxql/iterator.go
+++ b/influxql/iterator.go
@@ -165,6 +165,7 @@ func (itrs joinIterators) iterators() []Iterator {
 // AuxIterator represents an iterator that can split off separate auxilary iterators.
 type AuxIterator interface {
 	Iterator
+	IteratorCreator
 
 	// Auxilary iterator
 	Iterator(name string) Iterator

--- a/tsdb/store.go
+++ b/tsdb/store.go
@@ -417,27 +417,6 @@ func (s *Store) ShardRelativePath(id uint64) (string, error) {
 	return relativePath(s.path, shard.path)
 }
 
-// deleteSeries loops through the local shards and deletes the series data and metadata for the passed in series keys
-func (s *Store) deleteSeries(database string, keys []string) error {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-
-	db, ok := s.databaseIndexes[database]
-	if !ok {
-		return ErrDatabaseNotFound(database)
-	}
-
-	for _, sh := range s.shards {
-		if sh.index != db {
-			continue
-		}
-		if err := sh.DeleteSeries(keys); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
 // DeleteSeries loops through the local shards and deletes the series data and metadata for the passed in series keys
 func (s *Store) DeleteSeries(database string, sources influxql.Sources, condition influxql.Expr) error {
 	s.mu.RLock()


### PR DESCRIPTION
Binary expressions for float iterators have been implemented. Binary
expressions for other operations, like string, integer, and boolean,
still need to be implemented.
