### PR TITLE
Repair regressions in derivatives with group by tests

### DIFF
--- a/influxql/call_iterator.go
+++ b/influxql/call_iterator.go
@@ -140,7 +140,7 @@ func newFirstIterator(input Iterator, opt IteratorOptions) Iterator {
 // floatFirstReduce returns the first point sorted by time.
 func floatFirstReduce(prev, curr *FloatPoint, opt *reduceOptions) (int64, float64, []interface{}) {
 	if prev == nil || curr.Time < prev.Time || (curr.Time == prev.Time && curr.Value > prev.Value) {
-		return curr.Time, curr.Value, curr.Aux
+		return opt.startTime, curr.Value, curr.Aux
 	}
 	return prev.Time, prev.Value, prev.Aux
 }
@@ -158,7 +158,7 @@ func newLastIterator(input Iterator, opt IteratorOptions) Iterator {
 // floatLastReduce returns the last point sorted by time.
 func floatLastReduce(prev, curr *FloatPoint, opt *reduceOptions) (int64, float64, []interface{}) {
 	if prev == nil || curr.Time > prev.Time || (curr.Time == prev.Time && curr.Value > prev.Value) {
-		return curr.Time, curr.Value, curr.Aux
+		return opt.startTime, curr.Value, curr.Aux
 	}
 	return prev.Time, prev.Value, prev.Aux
 }

--- a/influxql/select.go
+++ b/influxql/select.go
@@ -282,7 +282,7 @@ func buildExprIterator(expr Expr, ic IteratorCreator, opt IteratorOptions) (Iter
 			percentile := expr.Args[1].(*NumberLiteral).Val
 			return newPercentileIterator(input, opt, percentile), nil
 		case "derivative", "non_negative_derivative":
-			input, err := buildExprIterator(expr.Args[0].(*VarRef), ic, opt)
+			input, err := buildExprIterator(expr.Args[0], ic, opt)
 			if err != nil {
 				return nil, err
 			}
@@ -290,6 +290,8 @@ func buildExprIterator(expr Expr, ic IteratorCreator, opt IteratorOptions) (Iter
 			interval := opt.DerivativeInterval()
 			isNonNegative := (expr.Name == "non_negative_derivative")
 
+			// Derivatives do not use GROUP BY intervals, so clear this option.
+			opt.Interval = Interval{}
 			return newDerivativeIterator(input, opt, interval, isNonNegative), nil
 		default:
 			panic(fmt.Sprintf("unsupported call: %s", expr.Name))


### PR DESCRIPTION
Also fixes the `first()` and `last()` calls to do the same thing as
`min()` and `max()` by returning the time corresponding to the start of
the interval rather than the point's real time.
