### PR TITLE
Integer Support & Emitter Refactoring

### DIFF
--- a/cmd/influxd/run/server_test.go
+++ b/cmd/influxd/run/server_test.go
@@ -2883,13 +2883,13 @@ func TestServer_Query_AggregateSelectors(t *testing.T) {
 			name:    "max - time",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT time, max(rx) FROM network where time >= '2000-01-01T00:00:00Z' AND time <= '2000-01-01T00:01:29Z' group by time(30s)`,
-			exp:     `{"results":[{"series":[{"name":"network","columns":["time","max"],"values":[["2000-01-01T00:00:10Z",40],["2000-01-01T00:00:40Z",50],["2000-01-01T00:01:10Z",90]]}]}]}`,
+			exp:     `{"results":[{"series":[{"name":"network","columns":["time","max"],"values":[["2000-01-01T00:00:00Z",40],["2000-01-01T00:00:30Z",50],["2000-01-01T00:01:00Z",90]]}]}]}`,
 		},
 		&Query{
 			name:    "max - time and tx",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT time, tx, max(rx) FROM network where time >= '2000-01-01T00:00:00Z' AND time <= '2000-01-01T00:01:29Z' group by time(30s)`,
-			exp:     `{"results":[{"series":[{"name":"network","columns":["time","tx","max"],"values":[["2000-01-01T00:00:10Z",50,40],["2000-01-01T00:00:40Z",70,50],["2000-01-01T00:01:10Z",10,90]]}]}]}`,
+			exp:     `{"results":[{"series":[{"name":"network","columns":["time","tx","max"],"values":[["2000-01-01T00:00:00Z",50,40],["2000-01-01T00:00:30Z",70,50],["2000-01-01T00:01:00Z",10,90]]}]}]}`,
 		},
 		&Query{
 			name:    "min - baseline 30s",
@@ -2907,13 +2907,13 @@ func TestServer_Query_AggregateSelectors(t *testing.T) {
 			name:    "min - time",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT time, min(rx) FROM network where time >= '2000-01-01T00:00:00Z' AND time <= '2000-01-01T00:01:29Z' group by time(30s)`,
-			exp:     `{"results":[{"series":[{"name":"network","columns":["time","min"],"values":[["2000-01-01T00:00:00Z",10],["2000-01-01T00:00:30Z",40],["2000-01-01T00:01:20Z",5]]}]}]}`,
+			exp:     `{"results":[{"series":[{"name":"network","columns":["time","min"],"values":[["2000-01-01T00:00:00Z",10],["2000-01-01T00:00:30Z",40],["2000-01-01T00:01:00Z",5]]}]}]}`,
 		},
 		&Query{
 			name:    "min - time and tx",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT time, tx, min(rx) FROM network where time >= '2000-01-01T00:00:00Z' AND time <= '2000-01-01T00:01:29Z' group by time(30s)`,
-			exp:     `{"results":[{"series":[{"name":"network","columns":["time","tx","min"],"values":[["2000-01-01T00:00:00Z",20,10],["2000-01-01T00:00:30Z",60,40],["2000-01-01T00:01:20Z",4,5]]}]}]}`,
+			exp:     `{"results":[{"series":[{"name":"network","columns":["time","tx","min"],"values":[["2000-01-01T00:00:00Z",20,10],["2000-01-01T00:00:30Z",60,40],["2000-01-01T00:01:00Z",4,5]]}]}]}`,
 		},
 		&Query{
 			name:    "max,min - baseline 30s",
@@ -2961,13 +2961,13 @@ func TestServer_Query_AggregateSelectors(t *testing.T) {
 			name:    "last - time",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT time, last(rx) FROM network where time >= '2000-01-01T00:00:00Z' AND time <= '2000-01-01T00:01:29Z' group by time(30s)`,
-			exp:     `{"results":[{"series":[{"name":"network","columns":["time","last"],"values":[["2000-01-01T00:00:20Z",40],["2000-01-01T00:00:50Z",50],["2000-01-01T00:01:20Z",5]]}]}]}`,
+			exp:     `{"results":[{"series":[{"name":"network","columns":["time","last"],"values":[["2000-01-01T00:00:00Z",40],["2000-01-01T00:00:30Z",50],["2000-01-01T00:01:00Z",5]]}]}]}`,
 		},
 		&Query{
 			name:    "last - time and tx",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT time, tx, last(rx) FROM network where time >= '2000-01-01T00:00:00Z' AND time <= '2000-01-01T00:01:29Z' group by time(30s)`,
-			exp:     `{"results":[{"series":[{"name":"network","columns":["time","tx","last"],"values":[["2000-01-01T00:00:20Z",55,40],["2000-01-01T00:00:50Z",40,50],["2000-01-01T00:01:20Z",4,5]]}]}]}`,
+			exp:     `{"results":[{"series":[{"name":"network","columns":["time","tx","last"],"values":[["2000-01-01T00:00:00Z",55,40],["2000-01-01T00:00:30Z",40,50],["2000-01-01T00:01:00Z",4,5]]}]}]}`,
 		},
 		&Query{
 			name:    "count - baseline 30s",
@@ -2991,7 +2991,7 @@ func TestServer_Query_AggregateSelectors(t *testing.T) {
 			name:    "distinct - baseline 30s",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT distinct(rx) FROM network where time >= '2000-01-01T00:00:00Z' AND time <= '2000-01-01T00:01:29Z' group by time(30s)`,
-			exp:     `{"results":[{"series":[{"name":"network","columns":["time","distinct"],"values":[["2000-01-01T00:00:00Z",[10,40]],["2000-01-01T00:00:30Z",[40,50]],["2000-01-01T00:01:00Z",[5,70,90]]]}]}]}`,
+			exp:     `{"results":[{"series":[{"name":"network","columns":["time","distinct"],"values":[["2000-01-01T00:00:00Z",10],["2000-01-01T00:00:10Z",40],["2000-01-01T00:00:30Z",40],["2000-01-01T00:00:40Z",50],["2000-01-01T00:01:00Z",70],["2000-01-01T00:01:10Z",90],["2000-01-01T00:01:20Z",5]]}]}]}`,
 		},
 		&Query{
 			name:    "distinct - time",

--- a/influxql/call_iterator_test.go
+++ b/influxql/call_iterator_test.go
@@ -152,9 +152,9 @@ func TestCallIterator_First_Float(t *testing.T) {
 
 	if a := (Iterators{itr}).ReadAll(); !deep.Equal(a, [][]influxql.Point{
 		{&influxql.FloatPoint{Time: 0, Value: 15, Tags: ParseTags("host=hostA")}},
-		{&influxql.FloatPoint{Time: 1, Value: 11, Tags: ParseTags("host=hostB")}},
-		{&influxql.FloatPoint{Time: 6, Value: 20, Tags: ParseTags("host=hostA")}},
-		{&influxql.FloatPoint{Time: 23, Value: 8, Tags: ParseTags("host=hostB")}},
+		{&influxql.FloatPoint{Time: 0, Value: 11, Tags: ParseTags("host=hostB")}},
+		{&influxql.FloatPoint{Time: 5, Value: 20, Tags: ParseTags("host=hostA")}},
+		{&influxql.FloatPoint{Time: 20, Value: 8, Tags: ParseTags("host=hostB")}},
 	}) {
 		t.Fatalf("unexpected points: %s", spew.Sdump(a))
 	}
@@ -181,10 +181,10 @@ func TestCallIterator_Last_Float(t *testing.T) {
 	)
 
 	if a := (Iterators{itr}).ReadAll(); !deep.Equal(a, [][]influxql.Point{
-		{&influxql.FloatPoint{Time: 2, Value: 10, Tags: ParseTags("host=hostA")}},
-		{&influxql.FloatPoint{Time: 1, Value: 11, Tags: ParseTags("host=hostB")}},
-		{&influxql.FloatPoint{Time: 6, Value: 20, Tags: ParseTags("host=hostA")}},
-		{&influxql.FloatPoint{Time: 23, Value: 8, Tags: ParseTags("host=hostB")}},
+		{&influxql.FloatPoint{Time: 0, Value: 10, Tags: ParseTags("host=hostA")}},
+		{&influxql.FloatPoint{Time: 0, Value: 11, Tags: ParseTags("host=hostB")}},
+		{&influxql.FloatPoint{Time: 5, Value: 20, Tags: ParseTags("host=hostA")}},
+		{&influxql.FloatPoint{Time: 20, Value: 8, Tags: ParseTags("host=hostB")}},
 	}) {
 		t.Fatalf("unexpected points: %s", spew.Sdump(a))
 	}

--- a/influxql/emitter_test.go
+++ b/influxql/emitter_test.go
@@ -23,7 +23,7 @@ func TestEmitter_Emit(t *testing.T) {
 			{Name: "cpu", Tags: ParseTags("region=north"), Time: 0, Value: 4},
 			{Name: "mem", Time: 4, Value: 5},
 		}},
-	})
+	}, true)
 	e.Columns = []string{"col1", "col2"}
 
 	// Verify the cpu region=west is emitted first.

--- a/influxql/influxql.go
+++ b/influxql/influxql.go
@@ -1,0 +1,4 @@
+package influxql
+
+//go:generate tmpl -data=@tmpldata iterator.gen.go.tmpl
+//go:generate tmpl -data=@tmpldata point.gen.go.tmpl

--- a/influxql/point.gen.go
+++ b/influxql/point.gen.go
@@ -50,6 +50,53 @@ func (a floatPointsByValue) Less(i, j int) bool { return a[i].Value < a[j].Value
 
 func (a floatPointsByValue) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
 
+// IntegerPoint represents a point with a int64 value.
+type IntegerPoint struct {
+	Name string
+	Tags Tags
+
+	Time  int64
+	Value int64
+	Aux   []interface{}
+}
+
+func (v *IntegerPoint) name() string       { return v.Name }
+func (v *IntegerPoint) tags() Tags         { return v.Tags }
+func (v *IntegerPoint) time() int64        { return v.Time }
+func (v *IntegerPoint) value() interface{} { return v.Value }
+func (v *IntegerPoint) aux() []interface{} { return v.Aux }
+
+// Clone returns a copy of v.
+func (v *IntegerPoint) Clone() *IntegerPoint {
+	if v == nil {
+		return nil
+	}
+
+	other := *v
+	if v.Aux != nil {
+		other.Aux = make([]interface{}, len(v.Aux))
+		copy(other.Aux, v.Aux)
+	}
+
+	return &other
+}
+
+// integerPoints represents a slice of points sortable by value.
+type integerPoints []IntegerPoint
+
+func (a integerPoints) Len() int           { return len(a) }
+func (a integerPoints) Less(i, j int) bool { return a[i].Time < a[j].Time }
+func (a integerPoints) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+
+// integerPointsByValue represents a slice of points sortable by value.
+type integerPointsByValue []IntegerPoint
+
+func (a integerPointsByValue) Len() int { return len(a) }
+
+func (a integerPointsByValue) Less(i, j int) bool { return a[i].Value < a[j].Value }
+
+func (a integerPointsByValue) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
+
 // StringPoint represents a point with a string value.
 type StringPoint struct {
 	Name string

--- a/influxql/point.go
+++ b/influxql/point.go
@@ -4,8 +4,6 @@ import (
 	"sort"
 )
 
-//go:generate tmpl -data=[{"Name":"Float","name":"float","Type":"float64","Nil":"math.NaN()"},{"Name":"String","name":"string","Type":"string","Nil":"\"\""},{"Name":"Boolean","name":"boolean","Type":"bool","Nil":"false"}] point.gen.go.tmpl
-
 // ZeroTime is the Unix nanosecond timestamp for time.Time{}.
 const ZeroTime = int64(-6795364578871345152)
 

--- a/influxql/tmpldata
+++ b/influxql/tmpldata
@@ -1,0 +1,26 @@
+[
+	{
+		"Name":"Float",
+		"name":"float",
+		"Type":"float64",
+		"Nil":"math.NaN()"
+	},
+	{
+		"Name":"Integer",
+		"name":"integer",
+		"Type":"int64",
+		"Nil":"0"
+	},
+	{
+		"Name":"String",
+		"name":"string",
+		"Type":"string",
+		"Nil":"\"\""
+	},
+	{
+		"Name":"Boolean",
+		"name":"boolean",
+		"Type":"bool",
+		"Nil":"false"
+	}
+]

--- a/tsdb/engine/tsm1/encoding.go
+++ b/tsdb/engine/tsm1/encoding.go
@@ -14,8 +14,8 @@ const (
 	// BlockFloat64 designates a block encodes float64 values
 	BlockFloat64 = byte(0)
 
-	// BlockInt64 designates a block encodes int64 values
-	BlockInt64 = byte(1)
+	// BlockInteger designates a block encodes int64 values
+	BlockInteger = byte(1)
 
 	// BlockBoolean designates a block encodes boolean values
 	BlockBoolean = byte(2)
@@ -39,7 +39,7 @@ type Value interface {
 func NewValue(t time.Time, value interface{}) Value {
 	switch v := value.(type) {
 	case int64:
-		return &Int64Value{time: t, value: v}
+		return &IntegerValue{time: t, value: v}
 	case float64:
 		return &FloatValue{time: t, value: v}
 	case bool:
@@ -91,7 +91,7 @@ func (a Values) Encode(buf []byte) ([]byte, error) {
 	case float64:
 		return encodeFloatBlock(buf, a)
 	case int64:
-		return encodeInt64Block(buf, a)
+		return encodeIntegerBlock(buf, a)
 	case bool:
 		return encodeBooleanBlock(buf, a)
 	case string:
@@ -126,7 +126,7 @@ func (a Values) InfluxQLType() (influxql.DataType, error) {
 func BlockType(block []byte) (byte, error) {
 	blockType := block[0]
 	switch blockType {
-	case BlockFloat64, BlockInt64, BlockBoolean, BlockString:
+	case BlockFloat64, BlockInteger, BlockBoolean, BlockString:
 		return blockType, nil
 	default:
 		return 0, fmt.Errorf("unknown block type: %d", blockType)
@@ -164,8 +164,8 @@ func DecodeBlock(block []byte, vals []Value) ([]Value, error) {
 			vals[i] = decoded[i]
 		}
 		return vals[:len(decoded)], err
-	case BlockInt64:
-		decoded, err := DecodeInt64Block(block, nil)
+	case BlockInteger:
+		decoded, err := DecodeIntegerBlock(block, nil)
 		if len(vals) < len(decoded) {
 			vals = make([]Value, len(decoded))
 		}
@@ -480,34 +480,34 @@ func (a BooleanValues) Len() int           { return len(a) }
 func (a BooleanValues) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
 func (a BooleanValues) Less(i, j int) bool { return a[i].Time().UnixNano() < a[j].Time().UnixNano() }
 
-type Int64Value struct {
+type IntegerValue struct {
 	time  time.Time
 	value int64
 }
 
-func (v *Int64Value) Time() time.Time {
+func (v *IntegerValue) Time() time.Time {
 	return v.time
 }
 
-func (v *Int64Value) Value() interface{} {
+func (v *IntegerValue) Value() interface{} {
 	return v.value
 }
 
-func (v *Int64Value) UnixNano() int64 {
+func (v *IntegerValue) UnixNano() int64 {
 	return v.time.UnixNano()
 }
 
-func (v *Int64Value) Size() int {
+func (v *IntegerValue) Size() int {
 	return 16
 }
 
-func (f *Int64Value) String() string {
+func (f *IntegerValue) String() string {
 	return fmt.Sprintf("%v %v", f.Time(), f.Value())
 }
 
-func encodeInt64Block(buf []byte, values []Value) ([]byte, error) {
+func encodeIntegerBlock(buf []byte, values []Value) ([]byte, error) {
 	tsEnc := NewTimeEncoder()
-	vEnc := NewInt64Encoder()
+	vEnc := NewIntegerEncoder()
 	for _, v := range values {
 		tsEnc.Write(v.Time())
 		vEnc.Write(v.Value().(int64))
@@ -525,14 +525,14 @@ func encodeInt64Block(buf []byte, values []Value) ([]byte, error) {
 	}
 
 	// Prepend the first timestamp of the block in the first 8 bytes
-	block := packBlockHeader(BlockInt64)
+	block := packBlockHeader(BlockInteger)
 	return append(block, packBlock(tb, vb)...), nil
 }
 
-func DecodeInt64Block(block []byte, a []*Int64Value) ([]*Int64Value, error) {
+func DecodeIntegerBlock(block []byte, a []*IntegerValue) ([]*IntegerValue, error) {
 	blockType := block[0]
-	if blockType != BlockInt64 {
-		return nil, fmt.Errorf("invalid block type: exp %d, got %d", BlockInt64, blockType)
+	if blockType != BlockInteger {
+		return nil, fmt.Errorf("invalid block type: exp %d, got %d", BlockInteger, blockType)
 	}
 
 	block = block[1:]
@@ -542,7 +542,7 @@ func DecodeInt64Block(block []byte, a []*Int64Value) ([]*Int64Value, error) {
 
 	// Setup our timestamp and value decoders
 	tsDec := NewTimeDecoder(tb)
-	vDec := NewInt64Decoder(vb)
+	vDec := NewIntegerDecoder(vb)
 
 	// Decode both a timestamp and value
 	i := 0
@@ -553,7 +553,7 @@ func DecodeInt64Block(block []byte, a []*Int64Value) ([]*Int64Value, error) {
 			a[i].time = ts
 			a[i].value = v
 		} else {
-			a = append(a, &Int64Value{ts, v})
+			a = append(a, &IntegerValue{ts, v})
 		}
 		i++
 	}
@@ -569,6 +569,31 @@ func DecodeInt64Block(block []byte, a []*Int64Value) ([]*Int64Value, error) {
 
 	return a[:i], nil
 }
+
+// IntegerValues represents a slice of integer values.
+type IntegerValues []*IntegerValue
+
+// Deduplicate returns a new slice with any values that have the same timestamp removed.
+// The Value that appears last in the slice is the one that is kept.
+func (a IntegerValues) Deduplicate() IntegerValues {
+	m := make(map[int64]*IntegerValue)
+	for _, val := range a {
+		m[val.UnixNano()] = val
+	}
+
+	other := make(IntegerValues, 0, len(m))
+	for _, val := range m {
+		other = append(other, val)
+	}
+
+	sort.Sort(other)
+	return other
+}
+
+// Sort methods
+func (a IntegerValues) Len() int           { return len(a) }
+func (a IntegerValues) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func (a IntegerValues) Less(i, j int) bool { return a[i].Time().UnixNano() < a[j].Time().UnixNano() }
 
 type StringValue struct {
 	time  time.Time

--- a/tsdb/engine/tsm1/encoding_test.go
+++ b/tsdb/engine/tsm1/encoding_test.go
@@ -201,7 +201,7 @@ func TestEncoding_BlockType(t *testing.T) {
 		blockType byte
 	}{
 		{value: float64(1.0), blockType: tsm1.BlockFloat64},
-		{value: int64(1), blockType: tsm1.BlockInt64},
+		{value: int64(1), blockType: tsm1.BlockInteger},
 		{value: true, blockType: tsm1.BlockBoolean},
 		{value: "string", blockType: tsm1.BlockString},
 	}
@@ -237,7 +237,7 @@ func TestEncoding_Count(t *testing.T) {
 		blockType byte
 	}{
 		{value: float64(1.0), blockType: tsm1.BlockFloat64},
-		{value: int64(1), blockType: tsm1.BlockInt64},
+		{value: int64(1), blockType: tsm1.BlockInteger},
 		{value: true, blockType: tsm1.BlockBoolean},
 		{value: "string", blockType: tsm1.BlockString},
 	}
@@ -338,7 +338,7 @@ func BenchmarkDecodeBlock_Float_TypeSpecific(b *testing.B) {
 	}
 }
 
-func BenchmarkDecodeBlock_Int64_Empty(b *testing.B) {
+func BenchmarkDecodeBlock_Integer_Empty(b *testing.B) {
 	valueCount := 1000
 	times := getTimes(valueCount, 60, time.Second)
 	values := make([]tsm1.Value, len(times))
@@ -361,7 +361,7 @@ func BenchmarkDecodeBlock_Int64_Empty(b *testing.B) {
 	}
 }
 
-func BenchmarkDecodeBlock_Int64_EqualSize(b *testing.B) {
+func BenchmarkDecodeBlock_Integer_EqualSize(b *testing.B) {
 	valueCount := 1000
 	times := getTimes(valueCount, 60, time.Second)
 	values := make([]tsm1.Value, len(times))
@@ -384,7 +384,7 @@ func BenchmarkDecodeBlock_Int64_EqualSize(b *testing.B) {
 	}
 }
 
-func BenchmarkDecodeBlock_Int64_TypeSpecific(b *testing.B) {
+func BenchmarkDecodeBlock_Integer_TypeSpecific(b *testing.B) {
 	valueCount := 1000
 	times := getTimes(valueCount, 60, time.Second)
 	values := make([]tsm1.Value, len(times))
@@ -397,13 +397,13 @@ func BenchmarkDecodeBlock_Int64_TypeSpecific(b *testing.B) {
 		b.Fatalf("unexpected error: %v", err)
 	}
 
-	decodedValues := make([]*tsm1.Int64Value, len(values))
+	decodedValues := make([]*tsm1.IntegerValue, len(values))
 	for i := 0; i < len(decodedValues); i++ {
-		decodedValues[i] = &tsm1.Int64Value{}
+		decodedValues[i] = &tsm1.IntegerValue{}
 	}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, err = tsm1.DecodeInt64Block(bytes, decodedValues)
+		_, err = tsm1.DecodeIntegerBlock(bytes, decodedValues)
 		if err != nil {
 			b.Fatalf("unexpected error decoding block: %v", err)
 		}

--- a/tsdb/engine/tsm1/file_store.go
+++ b/tsdb/engine/tsm1/file_store.go
@@ -23,6 +23,7 @@ type TSMFile interface {
 	// ReadAt returns all the values in the block identified by entry.
 	ReadAt(entry *IndexEntry, values []Value) ([]Value, error)
 	ReadFloatBlockAt(entry *IndexEntry, values []*FloatValue) ([]*FloatValue, error)
+	ReadIntegerBlockAt(entry *IndexEntry, values []*IntegerValue) ([]*IntegerValue, error)
 	ReadStringBlockAt(entry *IndexEntry, values []*StringValue) ([]*StringValue, error)
 	ReadBooleanBlockAt(entry *IndexEntry, values []*BooleanValue) ([]*BooleanValue, error)
 
@@ -756,6 +757,50 @@ func (c *KeyCursor) ReadFloatBlock(buf []*FloatValue) ([]*FloatValue, error) {
 	}
 
 	return FloatValues(values).Deduplicate(), err
+}
+
+// ReadIntegerBlock reads the next block as a set of integer values.
+func (c *KeyCursor) ReadIntegerBlock(buf []*IntegerValue) ([]*IntegerValue, error) {
+	// No matching blocks to decode
+	if len(c.current) == 0 {
+		return nil, nil
+	}
+
+	// First block is the oldest block containing the points we're search for.
+	first := c.current[0]
+	values, err := first.r.ReadIntegerBlockAt(first.entry, buf[:0])
+	first.read = true
+
+	// Only one block with this key and time range so return it
+	if len(c.current) == 1 {
+		return values, err
+	}
+
+	// Otherwise, search the remaining blocks that overlap and append their values so we can
+	// dedup them.
+	for i := 1; i < len(c.current); i++ {
+		cur := c.current[i]
+		if c.ascending && cur.entry.OverlapsTimeRange(first.entry.MinTime, first.entry.MaxTime) && !cur.read {
+			cur.read = true
+			c.pos++
+			v, err := cur.r.ReadIntegerBlockAt(cur.entry, nil)
+			if err != nil {
+				return nil, err
+			}
+			values = append(values, v...)
+		} else if !c.ascending && cur.entry.OverlapsTimeRange(first.entry.MinTime, first.entry.MaxTime) && !cur.read {
+			cur.read = true
+			c.pos--
+
+			v, err := cur.r.ReadIntegerBlockAt(cur.entry, nil)
+			if err != nil {
+				return nil, err
+			}
+			values = append(v, values...)
+		}
+	}
+
+	return IntegerValues(values).Deduplicate(), err
 }
 
 // ReadStringBlock reads the next block as a set of string values.

--- a/tsdb/engine/tsm1/int.go
+++ b/tsdb/engine/tsm1/int.go
@@ -1,6 +1,6 @@
 package tsm1
 
-// Int64 encoding uses two different strategies depending on the range of values in
+// Integer encoding uses two different strategies depending on the range of values in
 // the uncompressed data.  Encoded values are first encoding used zig zag encoding.
 // This interleaves positive and negative integers across a range of positive integers.
 //
@@ -36,30 +36,30 @@ const (
 	intCompressedRLE = 2
 )
 
-// Int64Encoder encoders int64 into byte slices
-type Int64Encoder interface {
+// IntegerEncoder encoders int64 into byte slices
+type IntegerEncoder interface {
 	Write(v int64)
 	Bytes() ([]byte, error)
 }
 
-// Int64Decoder decodes a byte slice into int64s
-type Int64Decoder interface {
+// IntegerDecoder decodes a byte slice into int64s
+type IntegerDecoder interface {
 	Next() bool
 	Read() int64
 	Error() error
 }
 
-type int64Encoder struct {
+type integerEncoder struct {
 	prev   int64
 	rle    bool
 	values []uint64
 }
 
-func NewInt64Encoder() Int64Encoder {
-	return &int64Encoder{rle: true}
+func NewIntegerEncoder() IntegerEncoder {
+	return &integerEncoder{rle: true}
 }
 
-func (e *int64Encoder) Write(v int64) {
+func (e *integerEncoder) Write(v int64) {
 	// Delta-encode each value as it's written.  This happens before
 	// ZigZagEncoding because the deltas could be negative.
 	delta := v - e.prev
@@ -72,7 +72,7 @@ func (e *int64Encoder) Write(v int64) {
 	e.values = append(e.values, enc)
 }
 
-func (e *int64Encoder) Bytes() ([]byte, error) {
+func (e *integerEncoder) Bytes() ([]byte, error) {
 	// Only run-length encode if it could be reduce storage size
 	if e.rle && len(e.values) > 2 {
 		return e.encodeRLE()
@@ -88,7 +88,7 @@ func (e *int64Encoder) Bytes() ([]byte, error) {
 	return e.encodePacked()
 }
 
-func (e *int64Encoder) encodeRLE() ([]byte, error) {
+func (e *integerEncoder) encodeRLE() ([]byte, error) {
 	// Large varints can take up to 10 bytes
 	b := make([]byte, 1+10*3)
 
@@ -107,7 +107,7 @@ func (e *int64Encoder) encodeRLE() ([]byte, error) {
 	return b[:i], nil
 }
 
-func (e *int64Encoder) encodePacked() ([]byte, error) {
+func (e *integerEncoder) encodePacked() ([]byte, error) {
 	if len(e.values) == 0 {
 		return nil, nil
 	}
@@ -133,7 +133,7 @@ func (e *int64Encoder) encodePacked() ([]byte, error) {
 	return b, nil
 }
 
-func (e *int64Encoder) encodeUncompressed() ([]byte, error) {
+func (e *integerEncoder) encodeUncompressed() ([]byte, error) {
 	if len(e.values) == 0 {
 		return nil, nil
 	}
@@ -148,7 +148,7 @@ func (e *int64Encoder) encodeUncompressed() ([]byte, error) {
 	return b, nil
 }
 
-type int64Decoder struct {
+type integerDecoder struct {
 	values []uint64
 	bytes  []byte
 	i      int
@@ -165,8 +165,8 @@ type int64Decoder struct {
 	err      error
 }
 
-func NewInt64Decoder(b []byte) Int64Decoder {
-	d := &int64Decoder{
+func NewIntegerDecoder(b []byte) IntegerDecoder {
+	d := &integerDecoder{
 		// 240 is the maximum number of values that can be encoded into a single uint64 using simple8b
 		values: make([]uint64, 240),
 	}
@@ -175,7 +175,7 @@ func NewInt64Decoder(b []byte) Int64Decoder {
 	return d
 }
 
-func (d *int64Decoder) SetBytes(b []byte) {
+func (d *integerDecoder) SetBytes(b []byte) {
 	if len(b) > 0 {
 		d.encoding = b[0] >> 4
 		d.bytes = b[1:]
@@ -185,7 +185,7 @@ func (d *int64Decoder) SetBytes(b []byte) {
 	d.n = 0
 }
 
-func (d *int64Decoder) Next() bool {
+func (d *integerDecoder) Next() bool {
 	if d.i >= d.n && len(d.bytes) == 0 {
 		return false
 	}
@@ -207,11 +207,11 @@ func (d *int64Decoder) Next() bool {
 	return d.i < d.n
 }
 
-func (d *int64Decoder) Error() error {
+func (d *integerDecoder) Error() error {
 	return d.err
 }
 
-func (d *int64Decoder) Read() int64 {
+func (d *integerDecoder) Read() int64 {
 	switch d.encoding {
 	case intCompressedRLE:
 		return ZigZagDecode(d.rleFirst + uint64(d.i)*d.rleDelta)
@@ -225,7 +225,7 @@ func (d *int64Decoder) Read() int64 {
 	}
 }
 
-func (d *int64Decoder) decodeRLE() {
+func (d *integerDecoder) decodeRLE() {
 	if len(d.bytes) == 0 {
 		return
 	}
@@ -256,7 +256,7 @@ func (d *int64Decoder) decodeRLE() {
 	d.bytes = nil
 }
 
-func (d *int64Decoder) decodePacked() {
+func (d *integerDecoder) decodePacked() {
 	if len(d.bytes) == 0 {
 		return
 	}
@@ -281,7 +281,7 @@ func (d *int64Decoder) decodePacked() {
 	d.bytes = d.bytes[8:]
 }
 
-func (d *int64Decoder) decodeUncompressed() {
+func (d *integerDecoder) decodeUncompressed() {
 	if len(d.bytes) == 0 {
 		return
 	}

--- a/tsdb/engine/tsm1/int_test.go
+++ b/tsdb/engine/tsm1/int_test.go
@@ -8,8 +8,8 @@ import (
 	"testing/quick"
 )
 
-func Test_Int64Encoder_NoValues(t *testing.T) {
-	enc := NewInt64Encoder()
+func Test_IntegerEncoder_NoValues(t *testing.T) {
+	enc := NewIntegerEncoder()
 	b, err := enc.Bytes()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -19,14 +19,14 @@ func Test_Int64Encoder_NoValues(t *testing.T) {
 		t.Fatalf("unexpected lenght: exp 0, got %v", len(b))
 	}
 
-	dec := NewInt64Decoder(b)
+	dec := NewIntegerDecoder(b)
 	if dec.Next() {
 		t.Fatalf("unexpected next value: got true, exp false")
 	}
 }
 
-func Test_Int64Encoder_One(t *testing.T) {
-	enc := NewInt64Encoder()
+func Test_IntegerEncoder_One(t *testing.T) {
+	enc := NewIntegerEncoder()
 	v1 := int64(1)
 
 	enc.Write(1)
@@ -39,7 +39,7 @@ func Test_Int64Encoder_One(t *testing.T) {
 		t.Fatalf("encoding type mismatch: exp uncompressed, got %v", got)
 	}
 
-	dec := NewInt64Decoder(b)
+	dec := NewIntegerDecoder(b)
 	if !dec.Next() {
 		t.Fatalf("unexpected next value: got true, exp false")
 	}
@@ -49,8 +49,8 @@ func Test_Int64Encoder_One(t *testing.T) {
 	}
 }
 
-func Test_Int64Encoder_Two(t *testing.T) {
-	enc := NewInt64Encoder()
+func Test_IntegerEncoder_Two(t *testing.T) {
+	enc := NewIntegerEncoder()
 	var v1, v2 int64 = 1, 2
 
 	enc.Write(v1)
@@ -65,7 +65,7 @@ func Test_Int64Encoder_Two(t *testing.T) {
 		t.Fatalf("encoding type mismatch: exp uncompressed, got %v", got)
 	}
 
-	dec := NewInt64Decoder(b)
+	dec := NewIntegerDecoder(b)
 	if !dec.Next() {
 		t.Fatalf("unexpected next value: got true, exp false")
 	}
@@ -83,8 +83,8 @@ func Test_Int64Encoder_Two(t *testing.T) {
 	}
 }
 
-func Test_Int64Encoder_Negative(t *testing.T) {
-	enc := NewInt64Encoder()
+func Test_IntegerEncoder_Negative(t *testing.T) {
+	enc := NewIntegerEncoder()
 	var v1, v2, v3 int64 = -2, 0, 1
 
 	enc.Write(v1)
@@ -100,7 +100,7 @@ func Test_Int64Encoder_Negative(t *testing.T) {
 		t.Fatalf("encoding type mismatch: exp uncompressed, got %v", got)
 	}
 
-	dec := NewInt64Decoder(b)
+	dec := NewIntegerDecoder(b)
 	if !dec.Next() {
 		t.Fatalf("unexpected next value: got true, exp false")
 	}
@@ -126,8 +126,8 @@ func Test_Int64Encoder_Negative(t *testing.T) {
 	}
 }
 
-func Test_Int64Encoder_Large_Range(t *testing.T) {
-	enc := NewInt64Encoder()
+func Test_IntegerEncoder_Large_Range(t *testing.T) {
+	enc := NewIntegerEncoder()
 	var v1, v2 int64 = math.MinInt64, math.MaxInt64
 	enc.Write(v1)
 	enc.Write(v2)
@@ -140,7 +140,7 @@ func Test_Int64Encoder_Large_Range(t *testing.T) {
 		t.Fatalf("encoding type mismatch: exp uncompressed, got %v", got)
 	}
 
-	dec := NewInt64Decoder(b)
+	dec := NewIntegerDecoder(b)
 	if !dec.Next() {
 		t.Fatalf("unexpected next value: got true, exp false")
 	}
@@ -158,8 +158,8 @@ func Test_Int64Encoder_Large_Range(t *testing.T) {
 	}
 }
 
-func Test_Int64Encoder_Uncompressed(t *testing.T) {
-	enc := NewInt64Encoder()
+func Test_IntegerEncoder_Uncompressed(t *testing.T) {
+	enc := NewIntegerEncoder()
 	var v1, v2, v3 int64 = 0, 1, 1 << 60
 
 	enc.Write(v1)
@@ -180,7 +180,7 @@ func Test_Int64Encoder_Uncompressed(t *testing.T) {
 		t.Fatalf("encoding type mismatch: exp uncompressed, got %v", got)
 	}
 
-	dec := NewInt64Decoder(b)
+	dec := NewIntegerDecoder(b)
 	if !dec.Next() {
 		t.Fatalf("unexpected next value: got true, exp false")
 	}
@@ -206,7 +206,7 @@ func Test_Int64Encoder_Uncompressed(t *testing.T) {
 	}
 }
 
-func Test_Int64Encoder_NegativeUncompressed(t *testing.T) {
+func Test_IntegerEncoder_NegativeUncompressed(t *testing.T) {
 	values := []int64{
 		-2352281900722994752, 1438442655375607923, -4110452567888190110,
 		-1221292455668011702, -1941700286034261841, -2836753127140407751,
@@ -217,7 +217,7 @@ func Test_Int64Encoder_NegativeUncompressed(t *testing.T) {
 		2761419461769776844, -1324397441074946198, -680758138988210958,
 		94468846694902125, -2394093124890745254, -2682139311758778198,
 	}
-	enc := NewInt64Encoder()
+	enc := NewIntegerEncoder()
 	for _, v := range values {
 		enc.Write(v)
 	}
@@ -231,7 +231,7 @@ func Test_Int64Encoder_NegativeUncompressed(t *testing.T) {
 		t.Fatalf("encoding type mismatch: exp uncompressed, got %v", got)
 	}
 
-	dec := NewInt64Decoder(b)
+	dec := NewIntegerDecoder(b)
 
 	i := 0
 	for dec.Next() {
@@ -250,8 +250,8 @@ func Test_Int64Encoder_NegativeUncompressed(t *testing.T) {
 	}
 }
 
-func Test_Int64Encoder_AllNegative(t *testing.T) {
-	enc := NewInt64Encoder()
+func Test_IntegerEncoder_AllNegative(t *testing.T) {
+	enc := NewIntegerEncoder()
 	values := []int64{
 		-10, -5, -1,
 	}
@@ -269,7 +269,7 @@ func Test_Int64Encoder_AllNegative(t *testing.T) {
 		t.Fatalf("encoding type mismatch: exp uncompressed, got %v", got)
 	}
 
-	dec := NewInt64Decoder(b)
+	dec := NewIntegerDecoder(b)
 	i := 0
 	for dec.Next() {
 		if i > len(values) {
@@ -287,8 +287,8 @@ func Test_Int64Encoder_AllNegative(t *testing.T) {
 	}
 }
 
-func Test_Int64Encoder_CounterPacked(t *testing.T) {
-	enc := NewInt64Encoder()
+func Test_IntegerEncoder_CounterPacked(t *testing.T) {
+	enc := NewIntegerEncoder()
 	values := []int64{
 		1e15, 1e15 + 1, 1e15 + 2, 1e15 + 3, 1e15 + 4, 1e15 + 6,
 	}
@@ -312,7 +312,7 @@ func Test_Int64Encoder_CounterPacked(t *testing.T) {
 		t.Fatalf("encoded length mismatch: got %v, exp %v", len(b), exp)
 	}
 
-	dec := NewInt64Decoder(b)
+	dec := NewIntegerDecoder(b)
 	i := 0
 	for dec.Next() {
 		if i > len(values) {
@@ -330,8 +330,8 @@ func Test_Int64Encoder_CounterPacked(t *testing.T) {
 	}
 }
 
-func Test_Int64Encoder_CounterRLE(t *testing.T) {
-	enc := NewInt64Encoder()
+func Test_IntegerEncoder_CounterRLE(t *testing.T) {
+	enc := NewIntegerEncoder()
 	values := []int64{
 		1e15, 1e15 + 1, 1e15 + 2, 1e15 + 3, 1e15 + 4, 1e15 + 5,
 	}
@@ -355,7 +355,7 @@ func Test_Int64Encoder_CounterRLE(t *testing.T) {
 		t.Fatalf("encoded length mismatch: got %v, exp %v", len(b), exp)
 	}
 
-	dec := NewInt64Decoder(b)
+	dec := NewIntegerDecoder(b)
 	i := 0
 	for dec.Next() {
 		if i > len(values) {
@@ -373,8 +373,8 @@ func Test_Int64Encoder_CounterRLE(t *testing.T) {
 	}
 }
 
-func Test_Int64Encoder_MinMax(t *testing.T) {
-	enc := NewInt64Encoder()
+func Test_IntegerEncoder_MinMax(t *testing.T) {
+	enc := NewIntegerEncoder()
 	values := []int64{
 		math.MinInt64, math.MaxInt64,
 	}
@@ -396,7 +396,7 @@ func Test_Int64Encoder_MinMax(t *testing.T) {
 		t.Fatalf("encoded length mismatch: got %v, exp %v", len(b), exp)
 	}
 
-	dec := NewInt64Decoder(b)
+	dec := NewIntegerDecoder(b)
 	i := 0
 	for dec.Next() {
 		if i > len(values) {
@@ -414,10 +414,10 @@ func Test_Int64Encoder_MinMax(t *testing.T) {
 	}
 }
 
-func Test_Int64Encoder_Quick(t *testing.T) {
+func Test_IntegerEncoder_Quick(t *testing.T) {
 	quick.Check(func(values []int64) bool {
 		// Write values to encoder.
-		enc := NewInt64Encoder()
+		enc := NewIntegerEncoder()
 		for _, v := range values {
 			enc.Write(v)
 		}
@@ -430,7 +430,7 @@ func Test_Int64Encoder_Quick(t *testing.T) {
 
 		// Read values out of decoder.
 		got := make([]int64, 0, len(values))
-		dec := NewInt64Decoder(buf)
+		dec := NewIntegerDecoder(buf)
 		for dec.Next() {
 			if err := dec.Error(); err != nil {
 				t.Fatal(err)
@@ -447,8 +447,8 @@ func Test_Int64Encoder_Quick(t *testing.T) {
 	}, nil)
 }
 
-func BenchmarkInt64EncoderRLE(b *testing.B) {
-	enc := NewInt64Encoder()
+func BenchmarkIntegerEncoderRLE(b *testing.B) {
+	enc := NewIntegerEncoder()
 	x := make([]int64, 1024)
 	for i := 0; i < len(x); i++ {
 		x[i] = int64(i)
@@ -461,8 +461,8 @@ func BenchmarkInt64EncoderRLE(b *testing.B) {
 	}
 }
 
-func BenchmarkInt64EncoderPackedSimple(b *testing.B) {
-	enc := NewInt64Encoder()
+func BenchmarkIntegerEncoderPackedSimple(b *testing.B) {
+	enc := NewIntegerEncoder()
 	x := make([]int64, 1024)
 	for i := 0; i < len(x); i++ {
 		// Small amount of randomness prevents RLE from being used
@@ -480,9 +480,9 @@ type byteSetter interface {
 	SetBytes(b []byte)
 }
 
-func BenchmarkInt64DecoderPackedSimple(b *testing.B) {
+func BenchmarkIntegerDecoderPackedSimple(b *testing.B) {
 	x := make([]int64, 1024)
-	enc := NewInt64Encoder()
+	enc := NewIntegerEncoder()
 	for i := 0; i < len(x); i++ {
 		// Small amount of randomness prevents RLE from being used
 		x[i] = int64(i) + int64(rand.Intn(10))
@@ -492,7 +492,7 @@ func BenchmarkInt64DecoderPackedSimple(b *testing.B) {
 
 	b.ResetTimer()
 
-	dec := NewInt64Decoder(bytes)
+	dec := NewIntegerDecoder(bytes)
 
 	for i := 0; i < b.N; i++ {
 		dec.(byteSetter).SetBytes(bytes)
@@ -501,9 +501,9 @@ func BenchmarkInt64DecoderPackedSimple(b *testing.B) {
 	}
 }
 
-func BenchmarkInt64DecoderRLE(b *testing.B) {
+func BenchmarkIntegerDecoderRLE(b *testing.B) {
 	x := make([]int64, 1024)
-	enc := NewInt64Encoder()
+	enc := NewIntegerEncoder()
 	for i := 0; i < len(x); i++ {
 		x[i] = int64(i)
 		enc.Write(x[i])
@@ -512,7 +512,7 @@ func BenchmarkInt64DecoderRLE(b *testing.B) {
 
 	b.ResetTimer()
 
-	dec := NewInt64Decoder(bytes)
+	dec := NewIntegerDecoder(bytes)
 
 	for i := 0; i < b.N; i++ {
 		dec.(byteSetter).SetBytes(bytes)

--- a/tsdb/engine/tsm1/iterator.gen.go
+++ b/tsdb/engine/tsm1/iterator.gen.go
@@ -217,7 +217,7 @@ func newFloatAscendingCursor(seek int64, cacheValues Values, tsmKeyCursor *KeyCu
 	})
 
 	c.tsm.keyCursor = tsmKeyCursor
-	c.tsm.buf = make([]*FloatValue, 1000)
+	c.tsm.buf = make([]*FloatValue, 10)
 	c.tsm.values, _ = c.tsm.keyCursor.ReadFloatBlock(c.tsm.buf)
 	c.tsm.pos = sort.Search(len(c.tsm.values), func(i int) bool {
 		return c.tsm.values[i].Time().UnixNano() >= seek
@@ -422,6 +422,334 @@ func (c *floatLiteralCursor) peek() (t int64, v interface{}) { return tsdb.EOF, 
 func (c *floatLiteralCursor) next() (t int64, v interface{}) { return tsdb.EOF, c.value }
 func (c *floatLiteralCursor) nextAt(seek int64) interface{}  { return c.value }
 
+type integerIterator struct {
+	cur   integerCursor
+	aux   []cursorAt
+	conds struct {
+		names []string
+		curs  []*bufCursor
+	}
+	opt influxql.IteratorOptions
+
+	m     map[string]interface{} // map used for condition evaluation
+	point influxql.IntegerPoint  // reusable buffer
+}
+
+func newIntegerIterator(name string, tags influxql.Tags, opt influxql.IteratorOptions, cur integerCursor, aux []cursorAt, conds []*bufCursor, condNames []string) *integerIterator {
+	itr := &integerIterator{
+		cur: cur,
+		aux: aux,
+		opt: opt,
+		point: influxql.IntegerPoint{
+			Name: name,
+			Tags: tags,
+		},
+	}
+
+	if len(aux) > 0 {
+		itr.point.Aux = make([]interface{}, len(aux))
+	}
+
+	if opt.Condition != nil {
+		itr.m = make(map[string]interface{}, len(aux)+len(conds))
+	}
+	itr.conds.names = condNames
+	itr.conds.curs = conds
+
+	return itr
+}
+
+// Next returns the next point from the iterator.
+func (itr *integerIterator) Next() *influxql.IntegerPoint {
+	for {
+		seek := tsdb.EOF
+
+		if itr.cur != nil {
+			// Read from the main cursor if we have one.
+			itr.point.Time, itr.point.Value = itr.cur.nextInteger()
+			seek = itr.point.Time
+		} else {
+			// Otherwise find lowest aux timestamp.
+			for i := range itr.aux {
+				if k, _ := itr.aux[i].peek(); seek == tsdb.EOF || k < seek {
+					seek = k
+				}
+			}
+			itr.point.Time = seek
+		}
+
+		// Exit if we have no more points or we are outside our time range.
+		if itr.point.Time == tsdb.EOF {
+			return nil
+		} else if itr.opt.Ascending && itr.point.Time > itr.opt.EndTime {
+			return nil
+		} else if !itr.opt.Ascending && itr.point.Time < itr.opt.StartTime {
+			return nil
+		}
+
+		// Read from each auxiliary cursor.
+		for i := range itr.opt.Aux {
+			itr.point.Aux[i] = itr.aux[i].nextAt(seek)
+		}
+
+		// Read from condition field cursors.
+		for i := range itr.conds.curs {
+			itr.m[itr.conds.names[i]] = itr.conds.curs[i].nextAt(seek)
+		}
+
+		// Evaluate condition, if one exists. Retry if it fails.
+		if itr.opt.Condition != nil && !influxql.EvalBool(itr.opt.Condition, itr.m) {
+			continue
+		}
+
+		return &itr.point
+	}
+}
+
+// Close closes the iterator.
+func (itr *integerIterator) Close() error { return nil }
+
+// integerCursor represents an object for iterating over a single integer field.
+type integerCursor interface {
+	cursor
+	nextInteger() (t int64, v int64)
+}
+
+func newIntegerCursor(seek int64, ascending bool, cacheValues Values, tsmKeyCursor *KeyCursor) integerCursor {
+	if ascending {
+		return newIntegerAscendingCursor(seek, cacheValues, tsmKeyCursor)
+	}
+	return newIntegerDescendingCursor(seek, cacheValues, tsmKeyCursor)
+}
+
+type integerAscendingCursor struct {
+	cache struct {
+		values Values
+		pos    int
+	}
+
+	tsm struct {
+		buf       []*IntegerValue
+		values    []*IntegerValue
+		pos       int
+		keyCursor *KeyCursor
+	}
+}
+
+func newIntegerAscendingCursor(seek int64, cacheValues Values, tsmKeyCursor *KeyCursor) *integerAscendingCursor {
+	c := &integerAscendingCursor{}
+
+	c.cache.values = cacheValues
+	c.cache.pos = sort.Search(len(c.cache.values), func(i int) bool {
+		return c.cache.values[i].Time().UnixNano() >= seek
+	})
+
+	c.tsm.keyCursor = tsmKeyCursor
+	c.tsm.buf = make([]*IntegerValue, 10)
+	c.tsm.values, _ = c.tsm.keyCursor.ReadIntegerBlock(c.tsm.buf)
+	c.tsm.pos = sort.Search(len(c.tsm.values), func(i int) bool {
+		return c.tsm.values[i].Time().UnixNano() >= seek
+	})
+
+	return c
+}
+
+// peekCache returns the current time/value from the cache.
+func (c *integerAscendingCursor) peekCache() (t int64, v int64) {
+	if c.cache.pos >= len(c.cache.values) {
+		return tsdb.EOF, 0
+	}
+
+	item := c.cache.values[c.cache.pos]
+	return item.UnixNano(), item.Value().(int64)
+}
+
+// peekTSM returns the current time/value from tsm.
+func (c *integerAscendingCursor) peekTSM() (t int64, v int64) {
+	if c.tsm.pos < 0 || c.tsm.pos >= len(c.tsm.values) {
+		c.tsm.keyCursor.Close()
+		return tsdb.EOF, 0
+	}
+
+	item := c.tsm.values[c.tsm.pos]
+	return item.Time().UnixNano(), item.Value().(int64)
+}
+
+// next returns the next key/value for the cursor.
+func (c *integerAscendingCursor) next() (int64, interface{}) { return c.nextInteger() }
+
+// nextInteger returns the next key/value for the cursor.
+func (c *integerAscendingCursor) nextInteger() (int64, int64) {
+	ckey, cvalue := c.peekCache()
+	tkey, tvalue := c.peekTSM()
+
+	// No more data in cache or in TSM files.
+	if ckey == tsdb.EOF && tkey == tsdb.EOF {
+		return tsdb.EOF, 0
+	}
+
+	// Both cache and tsm files have the same key, cache takes precedence.
+	if ckey == tkey {
+		c.nextCache()
+		c.nextTSM()
+		return tkey, tvalue
+	}
+
+	// Buffered cache key precedes that in TSM file.
+	if ckey != tsdb.EOF && (ckey < tkey || tkey == tsdb.EOF) {
+		c.nextCache()
+		return ckey, cvalue
+	}
+
+	// Buffered TSM key precedes that in cache.
+	c.nextTSM()
+	return tkey, tvalue
+}
+
+// nextCache returns the next value from the cache.
+func (c *integerAscendingCursor) nextCache() {
+	if c.cache.pos >= len(c.cache.values) {
+		return
+	}
+	c.cache.pos++
+}
+
+// nextTSM returns the next value from the TSM files.
+func (c *integerAscendingCursor) nextTSM() {
+	c.tsm.pos++
+	if c.tsm.pos >= len(c.tsm.values) {
+		c.tsm.keyCursor.Next()
+		c.tsm.values, _ = c.tsm.keyCursor.ReadIntegerBlock(c.tsm.buf)
+		if len(c.tsm.values) == 0 {
+			c.tsm.keyCursor.Close()
+			return
+		}
+		c.tsm.pos = 0
+	}
+}
+
+type integerDescendingCursor struct {
+	cache struct {
+		values Values
+		pos    int
+	}
+
+	tsm struct {
+		buf       []*IntegerValue
+		values    []*IntegerValue
+		pos       int
+		keyCursor *KeyCursor
+	}
+}
+
+func newIntegerDescendingCursor(seek int64, cacheValues Values, tsmKeyCursor *KeyCursor) *integerDescendingCursor {
+	c := &integerDescendingCursor{}
+
+	c.cache.values = cacheValues
+	c.cache.pos = sort.Search(len(c.cache.values), func(i int) bool {
+		return c.cache.values[i].Time().UnixNano() >= seek
+	})
+	if t, _ := c.peekCache(); t != seek {
+		c.cache.pos--
+	}
+
+	c.tsm.keyCursor = tsmKeyCursor
+	c.tsm.buf = make([]*IntegerValue, 1000)
+	c.tsm.values, _ = c.tsm.keyCursor.ReadIntegerBlock(c.tsm.buf)
+	c.tsm.pos = sort.Search(len(c.tsm.values), func(i int) bool {
+		return c.tsm.values[i].Time().UnixNano() >= seek
+	})
+	if t, _ := c.peekTSM(); t != seek {
+		c.tsm.pos--
+	}
+
+	return c
+}
+
+// peekCache returns the current time/value from the cache.
+func (c *integerDescendingCursor) peekCache() (t int64, v int64) {
+	if c.cache.pos < 0 || c.cache.pos >= len(c.cache.values) {
+		return tsdb.EOF, 0
+	}
+
+	item := c.cache.values[c.cache.pos]
+	return item.UnixNano(), item.Value().(int64)
+}
+
+// peekTSM returns the current time/value from tsm.
+func (c *integerDescendingCursor) peekTSM() (t int64, v int64) {
+	if c.tsm.pos < 0 || c.tsm.pos >= len(c.tsm.values) {
+		c.tsm.keyCursor.Close()
+		return tsdb.EOF, 0
+	}
+
+	item := c.tsm.values[c.tsm.pos]
+	return item.Time().UnixNano(), item.Value().(int64)
+}
+
+// next returns the next key/value for the cursor.
+func (c *integerDescendingCursor) next() (int64, interface{}) { return c.nextInteger() }
+
+// nextInteger returns the next key/value for the cursor.
+func (c *integerDescendingCursor) nextInteger() (int64, int64) {
+	ckey, cvalue := c.peekCache()
+	tkey, tvalue := c.peekTSM()
+
+	// No more data in cache or in TSM files.
+	if ckey == tsdb.EOF && tkey == tsdb.EOF {
+		return tsdb.EOF, 0
+	}
+
+	// Both cache and tsm files have the same key, cache takes precedence.
+	if ckey == tkey {
+		c.nextCache()
+		c.nextTSM()
+		return tkey, tvalue
+	}
+
+	// Buffered cache key precedes that in TSM file.
+	if ckey != tsdb.EOF && (ckey > tkey || tkey == tsdb.EOF) {
+		c.nextCache()
+		return ckey, cvalue
+	}
+
+	// Buffered TSM key precedes that in cache.
+	c.nextTSM()
+	return tkey, tvalue
+}
+
+// nextCache returns the next value from the cache.
+func (c *integerDescendingCursor) nextCache() {
+	if c.cache.pos < 0 {
+		return
+	}
+	c.cache.pos--
+}
+
+// nextTSM returns the next value from the TSM files.
+func (c *integerDescendingCursor) nextTSM() {
+	c.tsm.pos--
+	if c.tsm.pos < 0 {
+		c.tsm.keyCursor.Next()
+		c.tsm.values, _ = c.tsm.keyCursor.ReadIntegerBlock(c.tsm.buf)
+		if len(c.tsm.values) == 0 {
+			c.tsm.keyCursor.Close()
+			return
+		}
+		c.tsm.pos = 0
+	}
+}
+
+// integerLiteralCursor represents a cursor that always returns a single value.
+// It doesn't not have a time value so it can only be used with nextAt().
+type integerLiteralCursor struct {
+	value int64
+}
+
+func (c *integerLiteralCursor) peek() (t int64, v interface{}) { return tsdb.EOF, c.value }
+func (c *integerLiteralCursor) next() (t int64, v interface{}) { return tsdb.EOF, c.value }
+func (c *integerLiteralCursor) nextAt(seek int64) interface{}  { return c.value }
+
 type stringIterator struct {
 	cur   stringCursor
 	aux   []cursorAt
@@ -545,7 +873,7 @@ func newStringAscendingCursor(seek int64, cacheValues Values, tsmKeyCursor *KeyC
 	})
 
 	c.tsm.keyCursor = tsmKeyCursor
-	c.tsm.buf = make([]*StringValue, 1000)
+	c.tsm.buf = make([]*StringValue, 10)
 	c.tsm.values, _ = c.tsm.keyCursor.ReadStringBlock(c.tsm.buf)
 	c.tsm.pos = sort.Search(len(c.tsm.values), func(i int) bool {
 		return c.tsm.values[i].Time().UnixNano() >= seek
@@ -873,7 +1201,7 @@ func newBooleanAscendingCursor(seek int64, cacheValues Values, tsmKeyCursor *Key
 	})
 
 	c.tsm.keyCursor = tsmKeyCursor
-	c.tsm.buf = make([]*BooleanValue, 1000)
+	c.tsm.buf = make([]*BooleanValue, 10)
 	c.tsm.values, _ = c.tsm.keyCursor.ReadBooleanBlock(c.tsm.buf)
 	c.tsm.pos = sort.Search(len(c.tsm.values), func(i int) bool {
 		return c.tsm.values[i].Time().UnixNano() >= seek

--- a/tsdb/engine/tsm1/iterator.gen.go.tmpldata
+++ b/tsdb/engine/tsm1/iterator.gen.go.tmpldata
@@ -1,0 +1,26 @@
+[
+	{
+		"Name":"Float",
+		"name":"float",
+		"Type":"float64",
+		"Nil":"math.NaN()"
+	},
+	{
+		"Name":"Integer",
+		"name":"integer",
+		"Type":"int64",
+		"Nil":"0"
+	},
+	{
+		"Name":"String",
+		"name":"string",
+		"Type":"string",
+		"Nil":"\"\""
+	},
+	{
+		"Name":"Boolean",
+		"name":"boolean",
+		"Type":"bool",
+		"Nil":"false"
+	}
+]

--- a/tsdb/engine/tsm1/pools.go
+++ b/tsdb/engine/tsm1/pools.go
@@ -5,7 +5,7 @@ import "sync"
 var (
 	bufPool          sync.Pool
 	float64ValuePool sync.Pool
-	int64ValuePool   sync.Pool
+	integerValuePool sync.Pool
 	booleanValuePool sync.Pool
 	stringValuePool  sync.Pool
 )
@@ -55,9 +55,9 @@ func putFloat64Values(buf []Value) {
 }
 
 // getBuf returns a buffer with length size from the buffer pool.
-func getInt64Values(size int) []Value {
+func getIntegerValues(size int) []Value {
 	var buf []Value
-	x := int64ValuePool.Get()
+	x := integerValuePool.Get()
 	if x == nil {
 		buf = make([]Value, size)
 	} else {
@@ -69,15 +69,15 @@ func getInt64Values(size int) []Value {
 
 	for i, v := range buf {
 		if v == nil {
-			buf[i] = &Int64Value{}
+			buf[i] = &IntegerValue{}
 		}
 	}
 	return buf[:size]
 }
 
 // putBuf returns a buffer to the pool.
-func putInt64Values(buf []Value) {
-	int64ValuePool.Put(buf)
+func putIntegerValues(buf []Value) {
+	integerValuePool.Put(buf)
 }
 
 // getBuf returns a buffer with length size from the buffer pool.
@@ -136,8 +136,8 @@ func putValue(buf []Value) {
 		switch buf[0].(type) {
 		case *FloatValue:
 			putFloat64Values(buf)
-		case *Int64Value:
-			putInt64Values(buf)
+		case *IntegerValue:
+			putIntegerValues(buf)
 		case *BooleanValue:
 			putBooleanValues(buf)
 		case *StringValue:

--- a/tsdb/engine/tsm1/reader.go
+++ b/tsdb/engine/tsm1/reader.go
@@ -97,6 +97,7 @@ type blockAccessor interface {
 	readAll(key string) ([]Value, error)
 	readBlock(entry *IndexEntry, values []Value) ([]Value, error)
 	readFloatBlock(entry *IndexEntry, values []*FloatValue) ([]*FloatValue, error)
+	readIntegerBlock(entry *IndexEntry, values []*IntegerValue) ([]*IntegerValue, error)
 	readStringBlock(entry *IndexEntry, values []*StringValue) ([]*StringValue, error)
 	readBooleanBlock(entry *IndexEntry, values []*BooleanValue) ([]*BooleanValue, error)
 	readBytes(entry *IndexEntry, buf []byte) ([]byte, error)
@@ -211,6 +212,12 @@ func (t *TSMReader) ReadFloatBlockAt(entry *IndexEntry, vals []*FloatValue) ([]*
 	t.mu.RLock()
 	defer t.mu.RUnlock()
 	return t.accessor.readFloatBlock(entry, vals)
+}
+
+func (t *TSMReader) ReadIntegerBlockAt(entry *IndexEntry, vals []*IntegerValue) ([]*IntegerValue, error) {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return t.accessor.readIntegerBlock(entry, vals)
 }
 
 func (t *TSMReader) ReadStringBlockAt(entry *IndexEntry, vals []*StringValue) ([]*StringValue, error) {
@@ -806,6 +813,21 @@ func (f *fileAccessor) readFloatBlock(entry *IndexEntry, values []*FloatValue) (
 	return values, nil
 }
 
+func (f *fileAccessor) readIntegerBlock(entry *IndexEntry, values []*IntegerValue) ([]*IntegerValue, error) {
+	b, err := f.readBytes(entry, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO: Validate checksum
+	values, err = DecodeIntegerBlock(b, values)
+	if err != nil {
+		return nil, err
+	}
+
+	return values, nil
+}
+
 func (f *fileAccessor) readStringBlock(entry *IndexEntry, values []*StringValue) ([]*StringValue, error) {
 	b, err := f.readBytes(entry, nil)
 	if err != nil {
@@ -993,6 +1015,23 @@ func (m *mmapAccessor) readFloatBlock(entry *IndexEntry, values []*FloatValue) (
 	//TODO: Validate checksum
 	var err error
 	values, err = DecodeFloatBlock(m.b[entry.Offset+4:entry.Offset+int64(entry.Size)], values)
+	if err != nil {
+		return nil, err
+	}
+
+	return values, nil
+}
+
+func (m *mmapAccessor) readIntegerBlock(entry *IndexEntry, values []*IntegerValue) ([]*IntegerValue, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	if int64(len(m.b)) < entry.Offset+int64(entry.Size) {
+		return nil, ErrTSMClosed
+	}
+	//TODO: Validate checksum
+	var err error
+	values, err = DecodeIntegerBlock(m.b[entry.Offset+4:entry.Offset+int64(entry.Size)], values)
 	if err != nil {
 		return nil, err
 	}

--- a/tsdb/engine/tsm1/reader_test.go
+++ b/tsdb/engine/tsm1/reader_test.go
@@ -40,7 +40,7 @@ func TestTSMReader_Type(t *testing.T) {
 		fatal(t, "reading type", err)
 	}
 
-	if got, exp := typ, tsm1.BlockInt64; got != exp {
+	if got, exp := typ, tsm1.BlockInteger; got != exp {
 		t.Fatalf("type mismatch: got %v, exp %v", got, exp)
 	}
 }
@@ -512,7 +512,7 @@ func TestIndirectIndex_MaxBlocks(t *testing.T) {
 
 func TestIndirectIndex_Type(t *testing.T) {
 	index := tsm1.NewDirectIndex()
-	index.Add("cpu", tsm1.BlockInt64, time.Unix(0, 0), time.Unix(1, 0), 10, 20)
+	index.Add("cpu", tsm1.BlockInteger, time.Unix(0, 0), time.Unix(1, 0), 10, 20)
 
 	b, err := index.MarshalBinary()
 
@@ -526,7 +526,7 @@ func TestIndirectIndex_Type(t *testing.T) {
 		fatal(t, "reading type", err)
 	}
 
-	if got, exp := typ, tsm1.BlockInt64; got != exp {
+	if got, exp := typ, tsm1.BlockInteger; got != exp {
 		t.Fatalf("type mismatch: got %v, exp %v", got, exp)
 	}
 }

--- a/tsdb/engine/tsm1/wal.go
+++ b/tsdb/engine/tsm1/wal.go
@@ -31,7 +31,7 @@ const (
 	walEncodeBufSize = 4 * 1024 * 1024
 
 	float64EntryType = 1
-	int64EntryType   = 2
+	integerEntryType = 2
 	booleanEntryType = 3
 	stringEntryType  = 4
 )
@@ -382,7 +382,7 @@ func (w *WriteWALEntry) Encode(dst []byte) ([]byte, error) {
 		case float64:
 			dst[n] = float64EntryType
 		case int64:
-			dst[n] = int64EntryType
+			dst[n] = integerEntryType
 		case bool:
 			dst[n] = booleanEntryType
 		case string:
@@ -451,8 +451,8 @@ func (w *WriteWALEntry) UnmarshalBinary(b []byte) error {
 		switch typ {
 		case float64EntryType:
 			values = getFloat64Values(nvals)
-		case int64EntryType:
-			values = getInt64Values(nvals)
+		case integerEntryType:
+			values = getIntegerValues(nvals)
 		case booleanEntryType:
 			values = getBooleanValues(nvals)
 		case stringEntryType:
@@ -473,10 +473,10 @@ func (w *WriteWALEntry) UnmarshalBinary(b []byte) error {
 					fv.time = t
 					fv.value = v
 				}
-			case int64EntryType:
+			case integerEntryType:
 				v := int64(btou64(b[i : i+8]))
 				i += 8
-				if fv, ok := values[j].(*Int64Value); ok {
+				if fv, ok := values[j].(*IntegerValue); ok {
 					fv.time = t
 					fv.value = v
 				}

--- a/tsdb/query_executor.go
+++ b/tsdb/query_executor.go
@@ -291,7 +291,7 @@ func (q *QueryExecutor) PlanSelect(stmt *influxql.SelectStatement, chunkSize int
 	}
 
 	// Generate a row emitter from the iterator set.
-	em := influxql.NewEmitter(itrs)
+	em := influxql.NewEmitter(itrs, stmt.TimeAscending())
 	em.Columns = stmt.ColumnNames()
 
 	// Wrap emitter in an adapter to conform to the Executor interface.


### PR DESCRIPTION
## Overview

This pull request includes full support for the `Integer` data type in the query engine.

It also includes a refactoring of `Emitter` which pulls the `Join()` functionality into it. This allows us to avoid `null` values in iterators until they are finally emitted to the client.

/cc @jsternberg
