### PR TITLE
Implement casting support for different iterator types

### DIFF
--- a/influxql/ast.go
+++ b/influxql/ast.go
@@ -23,10 +23,10 @@ const (
 	Float = 1
 	// Integer means the data type is a integer
 	Integer = 2
-	// Boolean means the data type is a boolean.
-	Boolean = 3
 	// String means the data type is a string of text.
-	String = 4
+	String = 3
+	// Boolean means the data type is a boolean.
+	Boolean = 4
 	// Time means the data type is a time.
 	Time = 5
 	// Duration means the data type is a duration of time.
@@ -40,10 +40,10 @@ func InspectDataType(v interface{}) DataType {
 		return Float
 	case int64, int32, int:
 		return Integer
-	case bool:
-		return Boolean
 	case string:
 		return String
+	case bool:
+		return Boolean
 	case time.Time:
 		return Time
 	case time.Duration:
@@ -59,10 +59,10 @@ func (d DataType) String() string {
 		return "float"
 	case Integer:
 		return "integer"
-	case Boolean:
-		return "boolean"
 	case String:
 		return "string"
+	case Boolean:
+		return "boolean"
 	case Time:
 		return "time"
 	case Duration:

--- a/influxql/iterator.gen.go
+++ b/influxql/iterator.gen.go
@@ -17,11 +17,21 @@ type FloatIterator interface {
 }
 
 // newFloatIterators converts a slice of Iterator to a slice of FloatIterator.
-// Panic if any iterator in itrs is not a FloatIterator.
+// Drop and closes any iterator in itrs that is not a FloatIterator and cannot
+// be cast to a FloatIterator.
 func newFloatIterators(itrs []Iterator) []FloatIterator {
-	a := make([]FloatIterator, len(itrs))
-	for i, itr := range itrs {
-		a[i] = itr.(FloatIterator)
+	a := make([]FloatIterator, 0, len(itrs))
+	for _, itr := range itrs {
+		switch itr := itr.(type) {
+		case FloatIterator:
+			a = append(a, itr)
+
+		case IntegerIterator:
+			a = append(a, &integerFloatCastIterator{input: itr})
+
+		default:
+			itr.Close()
+		}
 	}
 	return a
 }
@@ -687,11 +697,18 @@ type IntegerIterator interface {
 }
 
 // newIntegerIterators converts a slice of Iterator to a slice of IntegerIterator.
-// Panic if any iterator in itrs is not a IntegerIterator.
+// Drop and closes any iterator in itrs that is not a IntegerIterator and cannot
+// be cast to a IntegerIterator.
 func newIntegerIterators(itrs []Iterator) []IntegerIterator {
-	a := make([]IntegerIterator, len(itrs))
-	for i, itr := range itrs {
-		a[i] = itr.(IntegerIterator)
+	a := make([]IntegerIterator, 0, len(itrs))
+	for _, itr := range itrs {
+		switch itr := itr.(type) {
+		case IntegerIterator:
+			a = append(a, itr)
+
+		default:
+			itr.Close()
+		}
 	}
 	return a
 }
@@ -1357,11 +1374,18 @@ type StringIterator interface {
 }
 
 // newStringIterators converts a slice of Iterator to a slice of StringIterator.
-// Panic if any iterator in itrs is not a StringIterator.
+// Drop and closes any iterator in itrs that is not a StringIterator and cannot
+// be cast to a StringIterator.
 func newStringIterators(itrs []Iterator) []StringIterator {
-	a := make([]StringIterator, len(itrs))
-	for i, itr := range itrs {
-		a[i] = itr.(StringIterator)
+	a := make([]StringIterator, 0, len(itrs))
+	for _, itr := range itrs {
+		switch itr := itr.(type) {
+		case StringIterator:
+			a = append(a, itr)
+
+		default:
+			itr.Close()
+		}
 	}
 	return a
 }
@@ -2027,11 +2051,18 @@ type BooleanIterator interface {
 }
 
 // newBooleanIterators converts a slice of Iterator to a slice of BooleanIterator.
-// Panic if any iterator in itrs is not a BooleanIterator.
+// Drop and closes any iterator in itrs that is not a BooleanIterator and cannot
+// be cast to a BooleanIterator.
 func newBooleanIterators(itrs []Iterator) []BooleanIterator {
-	a := make([]BooleanIterator, len(itrs))
-	for i, itr := range itrs {
-		a[i] = itr.(BooleanIterator)
+	a := make([]BooleanIterator, 0, len(itrs))
+	for _, itr := range itrs {
+		switch itr := itr.(type) {
+		case BooleanIterator:
+			a = append(a, itr)
+
+		default:
+			itr.Close()
+		}
 	}
 	return a
 }

--- a/influxql/iterator.gen.go.tmpl
+++ b/influxql/iterator.gen.go.tmpl
@@ -16,11 +16,21 @@ type {{.Name}}Iterator interface {
 }
 
 // new{{.Name}}Iterators converts a slice of Iterator to a slice of {{.Name}}Iterator.
-// Panic if any iterator in itrs is not a {{.Name}}Iterator.
+// Drop and closes any iterator in itrs that is not a {{.Name}}Iterator and cannot
+// be cast to a {{.Name}}Iterator.
 func new{{.Name}}Iterators(itrs []Iterator) []{{.Name}}Iterator {
-	a := make([]{{.Name}}Iterator, len(itrs))
-	for i, itr := range itrs {
-		a[i] = itr.({{.Name}}Iterator)
+	a := make([]{{.Name}}Iterator, 0, len(itrs))
+	for _, itr := range itrs {
+		switch itr := itr.(type) {
+		case {{.Name}}Iterator:
+			a = append(a, itr)
+{{if eq .Name "Float"}}
+		case IntegerIterator:
+			a = append(a, &integerFloatCastIterator{input: itr})
+{{end}}
+		default:
+			itr.Close()
+		}
 	}
 	return a
 }


### PR DESCRIPTION
Out of a list of iterators, an overarching iterator type is chosen and
only iterators of that type are returned for the merge iterator. If a
type can be cast to another type, an extra cast iterator is created to
handle that casting.

The only supported cast is from integers to floats.
