### PR TITLE
Fix nil shard panic

### DIFF
--- a/tsdb/store.go
+++ b/tsdb/store.go
@@ -186,7 +186,11 @@ func (s *Store) Shards(ids []uint64) []*Shard {
 	defer s.mu.RUnlock()
 	a := make([]*Shard, 0, len(ids))
 	for _, id := range ids {
-		a = append(a, s.shards[id])
+		sh := s.shards[id]
+		if sh == nil {
+			continue
+		}
+		a = append(a, sh)
 	}
 	return a
 }


### PR DESCRIPTION
## Overview

This pull request removes `nil` shards returned from `tsdb.Store.Shards()` which caused panics in some `SELECT`s. This can occur if the meta store has created shards before the store or if the shards are distributed throughout a cluster.

Fixes https://github.com/influxdata/influxdb/issues/5555

/cc @mjdesa
