### PR TITLE
Modify iterators to work across shards

### DIFF
--- a/influxql/ast.go
+++ b/influxql/ast.go
@@ -53,6 +53,14 @@ func InspectDataType(v interface{}) DataType {
 	}
 }
 
+func InspectDataTypes(a []interface{}) []DataType {
+	dta := make([]DataType, len(a))
+	for i, v := range a {
+		dta[i] = InspectDataType(v)
+	}
+	return dta
+}
+
 func (d DataType) String() string {
 	switch d {
 	case Float:

--- a/influxql/iterator.gen.go.tmpl
+++ b/influxql/iterator.gen.go.tmpl
@@ -420,6 +420,7 @@ type {{.name}}FillIterator struct {
 	curTime    int64
 	startTime  int64
 	endTime    int64
+	auxFields  []interface{}
 	opt        IteratorOptions
 }
 
@@ -440,12 +441,21 @@ func new{{.Name}}FillIterator(input {{.Name}}Iterator, seriesKeys SeriesList, ex
 		endTime, _ = opt.Window(opt.StartTime)
 	}
 
+	var auxFields []interface{}
+	if len(seriesKeys) > 0 {
+		series := seriesKeys[0]
+		if len(series.Aux) > 0 {
+			auxFields = make([]interface{}, len(series.Aux))
+		}
+	}
+
 	return &{{.name}}FillIterator{
 		input:      newBuf{{.Name}}Iterator(input),
 		seriesKeys: seriesKeys,
 		curTime:    startTime,
 		startTime:  startTime,
 		endTime:    endTime,
+		auxFields:  auxFields,
 		opt:        opt,
 	}
 }
@@ -465,7 +475,7 @@ func (itr *{{.name}}FillIterator) Next() *{{.Name}}Point {
 			Name: series.Name,
 			Tags: series.Tags,
 			Time: itr.curTime,
-			Aux:  series.Aux,
+			Aux:  itr.auxFields,
 		}
 
 		switch itr.opt.Fill {
@@ -491,16 +501,28 @@ func (itr *{{.name}}FillIterator) Next() *{{.Name}}Point {
 		itr.curTime = p.Time + int64(itr.opt.Interval.Duration)
 		if itr.curTime >= itr.endTime {
 			itr.curTime = itr.startTime
-			itr.index++
+			itr.nextSeries()
 		}
 	} else {
 		itr.curTime = p.Time - int64(itr.opt.Interval.Duration)
 		if itr.curTime < itr.endTime {
 			itr.curTime = itr.startTime
-			itr.index++
+			itr.nextSeries()
 		}
 	}
 	return p
+}
+
+func (itr *{{.name}}FillIterator) nextSeries() {
+	itr.index++
+	if itr.index < len(itr.seriesKeys) {
+		series := itr.seriesKeys[itr.index]
+		if len(series.Aux) > 0 {
+			itr.auxFields = make([]interface{}, len(series.Aux))
+		} else {
+			itr.auxFields = nil
+		}
+	}
 }
 
 // {{.name}}AuxIterator represents a {{.name}} implementation of AuxIterator.
@@ -510,17 +532,16 @@ type {{.name}}AuxIterator struct {
 	fields auxIteratorFields
 }
 
-func new{{.Name}}AuxIterator(input {{.Name}}Iterator, opt IteratorOptions) *{{.name}}AuxIterator {
+func new{{.Name}}AuxIterator(input {{.Name}}Iterator, seriesKeys SeriesList, opt IteratorOptions) *{{.name}}AuxIterator {
 	itr := &{{.name}}AuxIterator{
 		input:  newBuf{{.Name}}Iterator(input),
 		output: make(chan *{{.Name}}Point, 1),
 		fields: newAuxIteratorFields(opt),
 	}
 
-	// Initialize auxilary fields.
-	if p := itr.input.Next(); p != nil {
-		itr.output <- p
-		itr.fields.init(p)
+	// Initialize auxiliary fields.
+	if len(opt.Aux) > 0 {
+		itr.fields.init(seriesKeys)
 	}
 
 	go itr.stream()
@@ -528,7 +549,7 @@ func new{{.Name}}AuxIterator(input {{.Name}}Iterator, opt IteratorOptions) *{{.n
 }
 
 func (itr *{{.name}}AuxIterator) Close() error                  { return itr.input.Close() }
-func (itr *{{.name}}AuxIterator) Next() *{{.Name}}Point             { return <-itr.output }
+func (itr *{{.name}}AuxIterator) Next() *{{.Name}}Point         { return <-itr.output }
 func (itr *{{.name}}AuxIterator) Iterator(name string) Iterator { return itr.fields.iterator(name) }
 
 func (itr *{{.name}}AuxIterator) CreateIterator(opt IteratorOptions) (Iterator, error) {

--- a/influxql/iterator_test.go
+++ b/influxql/iterator_test.go
@@ -502,6 +502,9 @@ func TestFloatAuxIterator(t *testing.T) {
 			{Time: 0, Value: 1, Aux: []interface{}{float64(100), float64(200)}},
 			{Time: 1, Value: 2, Aux: []interface{}{float64(500), math.NaN()}},
 		}},
+		influxql.SeriesList{
+			{Aux: []influxql.DataType{influxql.Float, influxql.Float}},
+		},
 		influxql.IteratorOptions{Aux: []string{"f0", "f1"}},
 	)
 
@@ -781,22 +784,22 @@ func (ic *IteratorCreator) SeriesKeys(opt influxql.IteratorOptions) (influxql.Se
 	switch itr := itr.(type) {
 	case influxql.FloatIterator:
 		for p := itr.Next(); p != nil; p = itr.Next() {
-			s := influxql.Series{Name: p.Name, Tags: p.Tags}
+			s := influxql.Series{Name: p.Name, Tags: p.Tags, Aux: influxql.InspectDataTypes(p.Aux)}
 			seriesMap[s.ID()] = s
 		}
 	case influxql.IntegerIterator:
 		for p := itr.Next(); p != nil; p = itr.Next() {
-			s := influxql.Series{Name: p.Name, Tags: p.Tags}
+			s := influxql.Series{Name: p.Name, Tags: p.Tags, Aux: influxql.InspectDataTypes(p.Aux)}
 			seriesMap[s.ID()] = s
 		}
 	case influxql.StringIterator:
 		for p := itr.Next(); p != nil; p = itr.Next() {
-			s := influxql.Series{Name: p.Name, Tags: p.Tags}
+			s := influxql.Series{Name: p.Name, Tags: p.Tags, Aux: influxql.InspectDataTypes(p.Aux)}
 			seriesMap[s.ID()] = s
 		}
 	case influxql.BooleanIterator:
 		for p := itr.Next(); p != nil; p = itr.Next() {
-			s := influxql.Series{Name: p.Name, Tags: p.Tags}
+			s := influxql.Series{Name: p.Name, Tags: p.Tags, Aux: influxql.InspectDataTypes(p.Aux)}
 			seriesMap[s.ID()] = s
 		}
 	}

--- a/influxql/select.go
+++ b/influxql/select.go
@@ -85,8 +85,14 @@ func buildAuxIterators(fields Fields, ic IteratorCreator, opt IteratorOptions) (
 		input = NewLimitIterator(input, opt)
 	}
 
+	seriesKeys, err := ic.SeriesKeys(opt)
+	if err != nil {
+		input.Close()
+		return nil, err
+	}
+
 	// Wrap in an auxilary iterator to separate the fields.
-	aitr := NewAuxIterator(input, opt)
+	aitr := NewAuxIterator(input, seriesKeys, opt)
 
 	// Generate iterators for each field.
 	itrs := make([]Iterator, len(fields))
@@ -142,9 +148,14 @@ func buildFieldIterators(fields Fields, ic IteratorCreator, opt IteratorOptions)
 			return nil
 		}
 
+		seriesKeys, err := ic.SeriesKeys(opt)
+		if err != nil {
+			return err
+		}
+
 		// Build the aux iterators. Previous validation should ensure that only one
 		// call was present so we build an AuxIterator from that input.
-		aitr := NewAuxIterator(input, opt)
+		aitr := NewAuxIterator(input, seriesKeys, opt)
 		for i, f := range fields {
 			if itrs[i] != nil {
 				itrs[i] = aitr

--- a/influxql/select_test.go
+++ b/influxql/select_test.go
@@ -694,8 +694,8 @@ func TestSelect_Raw(t *testing.T) {
 
 		}
 		return &FloatIterator{Points: []influxql.FloatPoint{
-			{Time: 0, Aux: []interface{}{float64(1), math.NaN()}},
-			{Time: 1, Aux: []interface{}{math.NaN(), float64(2)}},
+			{Time: 0, Aux: []interface{}{float64(1), nil}},
+			{Time: 1, Aux: []interface{}{nil, float64(2)}},
 			{Time: 5, Aux: []interface{}{float64(3), float64(4)}},
 		}}, nil
 	}
@@ -707,10 +707,10 @@ func TestSelect_Raw(t *testing.T) {
 	} else if a := Iterators(itrs).ReadAll(); !deep.Equal(a, [][]influxql.Point{
 		{
 			&influxql.FloatPoint{Time: 0, Value: 1},
-			&influxql.FloatPoint{Time: 0, Value: math.NaN()},
+			&influxql.FloatPoint{Time: 0, Nil: true},
 		},
 		{
-			&influxql.FloatPoint{Time: 1, Value: math.NaN()},
+			&influxql.FloatPoint{Time: 1, Nil: true},
 			&influxql.FloatPoint{Time: 1, Value: 2},
 		},
 		{


### PR DESCRIPTION
Aux iterators now ask the iterator creator what series will be returned
and determine which aux fields to create based on the results.

The `tsdb.Shards` struct also creates a call iterator around the
iterators returned from each shard.
