### PR TITLE
Modify the fill iterator to not produce empty name/tags for a time range

### DIFF
--- a/cmd/influxd/run/server_test.go
+++ b/cmd/influxd/run/server_test.go
@@ -4425,7 +4425,7 @@ func TestServer_Query_Fill(t *testing.T) {
 		&Query{
 			name:    "fill with value, WHERE no values match condition",
 			command: `select mean(val) from fills where time >= '2009-11-10T23:00:00Z' and time < '2009-11-10T23:00:20Z' and val > 50 group by time(5s) FILL(1)`,
-			exp:     `{"results":[{"series":[{"name":"fills","columns":["time","mean"],"values":[["2009-11-10T23:00:00Z",1],["2009-11-10T23:00:05Z",1],["2009-11-10T23:00:10Z",1],["2009-11-10T23:00:15Z",1]]}]}]}`,
+			exp:     `{"results":[{}]}`,
 			params:  url.Values{"db": []string{"db0"}},
 		},
 		&Query{

--- a/influxql/iterator.gen.go.tmpl
+++ b/influxql/iterator.gen.go.tmpl
@@ -414,17 +414,21 @@ func (itr *{{.name}}LimitIterator) Next() *{{.Name}}Point {
 
 type {{.name}}FillIterator struct {
 	input      *buf{{.Name}}Iterator
-	seriesKeys SeriesList
 	prev       *{{.Name}}Point
-	index      int
-	curTime    int64
 	startTime  int64
 	endTime    int64
 	auxFields  []interface{}
+	done       bool
 	opt        IteratorOptions
+
+	window struct {
+		name string
+		tags Tags
+		time int64
+	}
 }
 
-func new{{.Name}}FillIterator(input {{.Name}}Iterator, seriesKeys SeriesList, expr Expr, opt IteratorOptions) *{{.name}}FillIterator {
+func new{{.Name}}FillIterator(input {{.Name}}Iterator, expr Expr, opt IteratorOptions) *{{.name}}FillIterator {
 	if opt.Fill == NullFill {
 		if expr, ok := expr.(*Call); ok && expr.Name == "count" {
 			opt.Fill = NumberFill
@@ -442,39 +446,74 @@ func new{{.Name}}FillIterator(input {{.Name}}Iterator, seriesKeys SeriesList, ex
 	}
 
 	var auxFields []interface{}
-	if len(seriesKeys) > 0 {
-		series := seriesKeys[0]
-		if len(series.Aux) > 0 {
-			auxFields = make([]interface{}, len(series.Aux))
-		}
+	if len(opt.Aux) > 0 {
+		auxFields = make([]interface{}, len(opt.Aux))
 	}
 
-	return &{{.name}}FillIterator{
+	itr := &{{.name}}FillIterator{
 		input:      newBuf{{.Name}}Iterator(input),
-		seriesKeys: seriesKeys,
-		curTime:    startTime,
 		startTime:  startTime,
 		endTime:    endTime,
 		auxFields:  auxFields,
 		opt:        opt,
 	}
+
+	p := itr.input.peek()
+	if p != nil {
+		itr.window.name, itr.window.tags = p.Name, p.Tags
+		itr.window.time = itr.startTime
+	} else {
+		itr.window.time = itr.endTime
+	}
+	return itr
 }
 
 func (itr *{{.name}}FillIterator) Close() error { return itr.input.Close() }
 
 func (itr *{{.name}}FillIterator) Next() *{{.Name}}Point {
 	p := itr.input.Next()
-	if itr.index >= len(itr.seriesKeys) {
-		return p
-	}
-	series := itr.seriesKeys[itr.index]
 
-	if p == nil || itr.curTime < p.Time || p.Name != series.Name || p.Tags.ID() != series.Tags.ID() {
-		itr.input.unread(p)
+	// Check if the next point is outside of our window or is nil.
+	for p == nil || p.Name != itr.window.name || p.Tags.ID() != itr.window.tags.ID() {
+		// If we are inside of an interval, unread the point and continue below to
+		// constructing a new point.
+		if itr.opt.Ascending {
+			if itr.window.time < itr.endTime {
+				itr.input.unread(p)
+				p = nil
+				break
+			}
+		} else {
+			if itr.window.time >= itr.endTime {
+				itr.input.unread(p)
+				p = nil
+				break
+			}
+		}
+
+		// We are *not* in a current interval. If there is no next point,
+		// we are at the end of all intervals.
+		if p == nil {
+			return nil
+		}
+
+		// Set the new interval.
+		itr.window.name, itr.window.tags = p.Name, p.Tags
+		itr.window.time = itr.startTime
+		itr.prev = nil
+		break
+	}
+
+	// Check if the point is our next expected point.
+	if p == nil || p.Time > itr.window.time {
+		if p != nil {
+			itr.input.unread(p)
+		}
+
 		p = &{{.Name}}Point{
-			Name: series.Name,
-			Tags: series.Tags,
-			Time: itr.curTime,
+			Name: itr.window.name,
+			Tags: itr.window.tags,
+			Time: itr.window.time,
 			Aux:  itr.auxFields,
 		}
 
@@ -490,39 +529,20 @@ func (itr *{{.name}}FillIterator) Next() *{{.Name}}Point {
 			} else {
 				p.Nil = true
 			}
-		default:
-			return p
 		}
 	} else {
 		itr.prev = p
 	}
 
+	// Advance the expected time. Do not advance to a new window here
+	// as there may be lingering points with the same timestamp in the previous
+	// window.
 	if itr.opt.Ascending {
-		itr.curTime = p.Time + int64(itr.opt.Interval.Duration)
-		if itr.curTime >= itr.endTime {
-			itr.curTime = itr.startTime
-			itr.nextSeries()
-		}
+		itr.window.time = p.Time + int64(itr.opt.Interval.Duration)
 	} else {
-		itr.curTime = p.Time - int64(itr.opt.Interval.Duration)
-		if itr.curTime < itr.endTime {
-			itr.curTime = itr.startTime
-			itr.nextSeries()
-		}
+		itr.window.time = p.Time - int64(itr.opt.Interval.Duration)
 	}
 	return p
-}
-
-func (itr *{{.name}}FillIterator) nextSeries() {
-	itr.index++
-	if itr.index < len(itr.seriesKeys) {
-		series := itr.seriesKeys[itr.index]
-		if len(series.Aux) > 0 {
-			itr.auxFields = make([]interface{}, len(series.Aux))
-		} else {
-			itr.auxFields = nil
-		}
-	}
 }
 
 // {{.name}}AuxIterator represents a {{.name}} implementation of AuxIterator.

--- a/influxql/iterator.go
+++ b/influxql/iterator.go
@@ -185,16 +185,16 @@ func NewDedupeIterator(input Iterator) Iterator {
 }
 
 // NewFillIterator returns an iterator that fills in missing points in an aggregate.
-func NewFillIterator(input Iterator, seriesKeys SeriesList, expr Expr, opt IteratorOptions) Iterator {
+func NewFillIterator(input Iterator, expr Expr, opt IteratorOptions) Iterator {
 	switch input := input.(type) {
 	case FloatIterator:
-		return newFloatFillIterator(input, seriesKeys, expr, opt)
+		return newFloatFillIterator(input, expr, opt)
 	case IntegerIterator:
-		return newIntegerFillIterator(input, seriesKeys, expr, opt)
+		return newIntegerFillIterator(input, expr, opt)
 	case StringIterator:
-		return newStringFillIterator(input, seriesKeys, expr, opt)
+		return newStringFillIterator(input, expr, opt)
 	case BooleanIterator:
-		return newBooleanFillIterator(input, seriesKeys, expr, opt)
+		return newBooleanFillIterator(input, expr, opt)
 	default:
 		panic(fmt.Sprintf("unsupported fill iterator type: %T", input))
 	}

--- a/influxql/iterator_test.go
+++ b/influxql/iterator_test.go
@@ -495,6 +495,114 @@ func TestSortedMergeIterator_Cast_Float(t *testing.T) {
 	}
 }
 
+// Ensure limit iterators work with limit and offset.
+func TestLimitIterator_Float(t *testing.T) {
+	input := &FloatIterator{Points: []influxql.FloatPoint{
+		{Name: "cpu", Time: 0, Value: 1},
+		{Name: "cpu", Time: 5, Value: 3},
+		{Name: "cpu", Time: 10, Value: 5},
+		{Name: "mem", Time: 5, Value: 3},
+		{Name: "mem", Time: 7, Value: 8},
+	}}
+
+	itr := influxql.NewLimitIterator(input, influxql.IteratorOptions{
+		Limit:  1,
+		Offset: 1,
+	})
+
+	if a := Iterators([]influxql.Iterator{itr}).ReadAll(); !deep.Equal(a, [][]influxql.Point{
+		{&influxql.FloatPoint{Name: "cpu", Time: 5, Value: 3}},
+		{&influxql.FloatPoint{Name: "mem", Time: 7, Value: 8}},
+	}) {
+		t.Fatalf("unexpected points: %s", spew.Sdump(a))
+	}
+
+	if !input.Closed {
+		t.Error("iterator not closed")
+	}
+}
+
+// Ensure limit iterators work with limit and offset.
+func TestLimitIterator_Integer(t *testing.T) {
+	input := &IntegerIterator{Points: []influxql.IntegerPoint{
+		{Name: "cpu", Time: 0, Value: 1},
+		{Name: "cpu", Time: 5, Value: 3},
+		{Name: "cpu", Time: 10, Value: 5},
+		{Name: "mem", Time: 5, Value: 3},
+		{Name: "mem", Time: 7, Value: 8},
+	}}
+
+	itr := influxql.NewLimitIterator(input, influxql.IteratorOptions{
+		Limit:  1,
+		Offset: 1,
+	})
+
+	if a := Iterators([]influxql.Iterator{itr}).ReadAll(); !deep.Equal(a, [][]influxql.Point{
+		{&influxql.IntegerPoint{Name: "cpu", Time: 5, Value: 3}},
+		{&influxql.IntegerPoint{Name: "mem", Time: 7, Value: 8}},
+	}) {
+		t.Fatalf("unexpected points: %s", spew.Sdump(a))
+	}
+
+	if !input.Closed {
+		t.Error("iterator not closed")
+	}
+}
+
+// Ensure limit iterators work with limit and offset.
+func TestLimitIterator_String(t *testing.T) {
+	input := &StringIterator{Points: []influxql.StringPoint{
+		{Name: "cpu", Time: 0, Value: "a"},
+		{Name: "cpu", Time: 5, Value: "b"},
+		{Name: "cpu", Time: 10, Value: "c"},
+		{Name: "mem", Time: 5, Value: "d"},
+		{Name: "mem", Time: 7, Value: "e"},
+	}}
+
+	itr := influxql.NewLimitIterator(input, influxql.IteratorOptions{
+		Limit:  1,
+		Offset: 1,
+	})
+
+	if a := Iterators([]influxql.Iterator{itr}).ReadAll(); !deep.Equal(a, [][]influxql.Point{
+		{&influxql.StringPoint{Name: "cpu", Time: 5, Value: "b"}},
+		{&influxql.StringPoint{Name: "mem", Time: 7, Value: "e"}},
+	}) {
+		t.Fatalf("unexpected points: %s", spew.Sdump(a))
+	}
+
+	if !input.Closed {
+		t.Error("iterator not closed")
+	}
+}
+
+// Ensure limit iterators work with limit and offset.
+func TestLimitIterator_Boolean(t *testing.T) {
+	input := &BooleanIterator{Points: []influxql.BooleanPoint{
+		{Name: "cpu", Time: 0, Value: true},
+		{Name: "cpu", Time: 5, Value: false},
+		{Name: "cpu", Time: 10, Value: true},
+		{Name: "mem", Time: 5, Value: false},
+		{Name: "mem", Time: 7, Value: true},
+	}}
+
+	itr := influxql.NewLimitIterator(input, influxql.IteratorOptions{
+		Limit:  1,
+		Offset: 1,
+	})
+
+	if a := Iterators([]influxql.Iterator{itr}).ReadAll(); !deep.Equal(a, [][]influxql.Point{
+		{&influxql.BooleanPoint{Name: "cpu", Time: 5, Value: false}},
+		{&influxql.BooleanPoint{Name: "mem", Time: 7, Value: true}},
+	}) {
+		t.Fatalf("unexpected points: %s", spew.Sdump(a))
+	}
+
+	if !input.Closed {
+		t.Error("iterator not closed")
+	}
+}
+
 // Ensure auxilary iterators can be created for auxilary fields.
 func TestFloatAuxIterator(t *testing.T) {
 	itr := influxql.NewAuxIterator(

--- a/influxql/select.go
+++ b/influxql/select.go
@@ -321,12 +321,7 @@ func buildExprIterator(expr Expr, ic IteratorCreator, opt IteratorOptions) (Iter
 		}
 
 		if !opt.Interval.IsZero() && opt.Fill != NoFill {
-			seriesKeys, err := ic.SeriesKeys(opt)
-			if err != nil {
-				itr.Close()
-				return nil, err
-			}
-			itr = NewFillIterator(itr, seriesKeys, expr, opt)
+			itr = NewFillIterator(itr, expr, opt)
 		}
 		return itr, nil
 	case *BinaryExpr:

--- a/influxql/select_test.go
+++ b/influxql/select_test.go
@@ -725,10 +725,17 @@ func TestSelect_Raw(t *testing.T) {
 func TestSelect_BinaryExpr_Float(t *testing.T) {
 	var ic IteratorCreator
 	ic.CreateIteratorFn = func(opt influxql.IteratorOptions) (influxql.Iterator, error) {
+		makeAuxFields := func(value float64) []interface{} {
+			aux := make([]interface{}, len(opt.Aux))
+			for i := range aux {
+				aux[i] = value
+			}
+			return aux
+		}
 		return &FloatIterator{Points: []influxql.FloatPoint{
-			{Name: "cpu", Time: 0 * Second, Value: 20, Aux: []interface{}{float64(20)}},
-			{Name: "cpu", Time: 5 * Second, Value: 10, Aux: []interface{}{float64(10)}},
-			{Name: "cpu", Time: 9 * Second, Value: 19, Aux: []interface{}{float64(19)}},
+			{Name: "cpu", Time: 0 * Second, Value: 20, Aux: makeAuxFields(20)},
+			{Name: "cpu", Time: 5 * Second, Value: 10, Aux: makeAuxFields(10)},
+			{Name: "cpu", Time: 9 * Second, Value: 19, Aux: makeAuxFields(19)},
 		}}, nil
 	}
 
@@ -756,6 +763,15 @@ func TestSelect_BinaryExpr_Float(t *testing.T) {
 			},
 		},
 		{
+			Name:      "two variable binary add",
+			Statement: `SELECT value + value FROM cpu`,
+			Points: [][]influxql.Point{
+				{&influxql.FloatPoint{Name: "cpu", Time: 0 * Second, Value: 40}},
+				{&influxql.FloatPoint{Name: "cpu", Time: 5 * Second, Value: 20}},
+				{&influxql.FloatPoint{Name: "cpu", Time: 9 * Second, Value: 38}},
+			},
+		},
+		{
 			Name:      "rhs binary multiply",
 			Statement: `SELECT value * 2 FROM cpu`,
 			Points: [][]influxql.Point{
@@ -771,6 +787,15 @@ func TestSelect_BinaryExpr_Float(t *testing.T) {
 				{&influxql.FloatPoint{Name: "cpu", Time: 0 * Second, Value: 40}},
 				{&influxql.FloatPoint{Name: "cpu", Time: 5 * Second, Value: 20}},
 				{&influxql.FloatPoint{Name: "cpu", Time: 9 * Second, Value: 38}},
+			},
+		},
+		{
+			Name:      "two variable binary multiply",
+			Statement: `SELECT value * value FROM cpu`,
+			Points: [][]influxql.Point{
+				{&influxql.FloatPoint{Name: "cpu", Time: 0 * Second, Value: 400}},
+				{&influxql.FloatPoint{Name: "cpu", Time: 5 * Second, Value: 100}},
+				{&influxql.FloatPoint{Name: "cpu", Time: 9 * Second, Value: 361}},
 			},
 		},
 		{
@@ -792,6 +817,15 @@ func TestSelect_BinaryExpr_Float(t *testing.T) {
 			},
 		},
 		{
+			Name:      "two variable binary subtract",
+			Statement: `SELECT value - value FROM cpu`,
+			Points: [][]influxql.Point{
+				{&influxql.FloatPoint{Name: "cpu", Time: 0 * Second, Value: 0}},
+				{&influxql.FloatPoint{Name: "cpu", Time: 5 * Second, Value: 0}},
+				{&influxql.FloatPoint{Name: "cpu", Time: 9 * Second, Value: 0}},
+			},
+		},
+		{
 			Name:      "rhs binary division",
 			Statement: `SELECT value / 2 FROM cpu`,
 			Points: [][]influxql.Point{
@@ -809,6 +843,15 @@ func TestSelect_BinaryExpr_Float(t *testing.T) {
 				{&influxql.FloatPoint{Name: "cpu", Time: 9 * Second, Value: 2}},
 			},
 		},
+		{
+			Name:      "two variable binary division",
+			Statement: `SELECT value / value FROM cpu`,
+			Points: [][]influxql.Point{
+				{&influxql.FloatPoint{Name: "cpu", Time: 0 * Second, Value: 1}},
+				{&influxql.FloatPoint{Name: "cpu", Time: 5 * Second, Value: 1}},
+				{&influxql.FloatPoint{Name: "cpu", Time: 9 * Second, Value: 1}},
+			},
+		},
 	} {
 		itrs, err := influxql.Select(MustParseSelectStatement(test.Statement), &ic)
 		if err != nil {
@@ -823,10 +866,17 @@ func TestSelect_BinaryExpr_Float(t *testing.T) {
 func TestSelect_BinaryExpr_Integer(t *testing.T) {
 	var ic IteratorCreator
 	ic.CreateIteratorFn = func(opt influxql.IteratorOptions) (influxql.Iterator, error) {
+		makeAuxFields := func(value int64) []interface{} {
+			aux := make([]interface{}, len(opt.Aux))
+			for i := range aux {
+				aux[i] = value
+			}
+			return aux
+		}
 		return &IntegerIterator{Points: []influxql.IntegerPoint{
-			{Name: "cpu", Time: 0 * Second, Value: 20, Aux: []interface{}{int64(20)}},
-			{Name: "cpu", Time: 5 * Second, Value: 10, Aux: []interface{}{int64(10)}},
-			{Name: "cpu", Time: 9 * Second, Value: 19, Aux: []interface{}{int64(19)}},
+			{Name: "cpu", Time: 0 * Second, Value: 20, Aux: makeAuxFields(20)},
+			{Name: "cpu", Time: 5 * Second, Value: 10, Aux: makeAuxFields(10)},
+			{Name: "cpu", Time: 9 * Second, Value: 19, Aux: makeAuxFields(19)},
 		}}, nil
 	}
 
@@ -854,6 +904,15 @@ func TestSelect_BinaryExpr_Integer(t *testing.T) {
 			},
 		},
 		{
+			Name:      "two variable binary add",
+			Statement: `SELECT value + value FROM cpu`,
+			Points: [][]influxql.Point{
+				{&influxql.IntegerPoint{Name: "cpu", Time: 0 * Second, Value: 40}},
+				{&influxql.IntegerPoint{Name: "cpu", Time: 5 * Second, Value: 20}},
+				{&influxql.IntegerPoint{Name: "cpu", Time: 9 * Second, Value: 38}},
+			},
+		},
+		{
 			Name:      "rhs binary multiply",
 			Statement: `SELECT value * 2 FROM cpu`,
 			Points: [][]influxql.Point{
@@ -869,6 +928,15 @@ func TestSelect_BinaryExpr_Integer(t *testing.T) {
 				{&influxql.IntegerPoint{Name: "cpu", Time: 0 * Second, Value: 40}},
 				{&influxql.IntegerPoint{Name: "cpu", Time: 5 * Second, Value: 20}},
 				{&influxql.IntegerPoint{Name: "cpu", Time: 9 * Second, Value: 38}},
+			},
+		},
+		{
+			Name:      "two variable binary multiply",
+			Statement: `SELECT value * value FROM cpu`,
+			Points: [][]influxql.Point{
+				{&influxql.IntegerPoint{Name: "cpu", Time: 0 * Second, Value: 400}},
+				{&influxql.IntegerPoint{Name: "cpu", Time: 5 * Second, Value: 100}},
+				{&influxql.IntegerPoint{Name: "cpu", Time: 9 * Second, Value: 361}},
 			},
 		},
 		{
@@ -890,6 +958,15 @@ func TestSelect_BinaryExpr_Integer(t *testing.T) {
 			},
 		},
 		{
+			Name:      "two variable binary subtract",
+			Statement: `SELECT value - value FROM cpu`,
+			Points: [][]influxql.Point{
+				{&influxql.IntegerPoint{Name: "cpu", Time: 0 * Second, Value: 0}},
+				{&influxql.IntegerPoint{Name: "cpu", Time: 5 * Second, Value: 0}},
+				{&influxql.IntegerPoint{Name: "cpu", Time: 9 * Second, Value: 0}},
+			},
+		},
+		{
 			Name:      "rhs binary division",
 			Statement: `SELECT value / 2 FROM cpu`,
 			Points: [][]influxql.Point{
@@ -905,6 +982,15 @@ func TestSelect_BinaryExpr_Integer(t *testing.T) {
 				{&influxql.IntegerPoint{Name: "cpu", Time: 0 * Second, Value: 1}},
 				{&influxql.IntegerPoint{Name: "cpu", Time: 5 * Second, Value: 3}},
 				{&influxql.IntegerPoint{Name: "cpu", Time: 9 * Second, Value: 2}},
+			},
+		},
+		{
+			Name:      "two variable binary division",
+			Statement: `SELECT value / value FROM cpu`,
+			Points: [][]influxql.Point{
+				{&influxql.IntegerPoint{Name: "cpu", Time: 0 * Second, Value: 1}},
+				{&influxql.IntegerPoint{Name: "cpu", Time: 5 * Second, Value: 1}},
+				{&influxql.IntegerPoint{Name: "cpu", Time: 9 * Second, Value: 1}},
 			},
 		},
 	} {

--- a/influxql/select_test.go
+++ b/influxql/select_test.go
@@ -470,12 +470,6 @@ func TestSelect_Fill_Null_Float(t *testing.T) {
 			{Name: "cpu", Tags: ParseTags("host=A"), Time: 12 * Second, Value: 2},
 		}}, nil
 	}
-	ic.SeriesKeysFn = func(opt influxql.IteratorOptions) (influxql.SeriesList, error) {
-		return influxql.SeriesList{
-			{Name: "cpu", Tags: ParseTags("host=A")},
-			{Name: "cpu", Tags: ParseTags("host=B")},
-		}, nil
-	}
 
 	// Execute selection.
 	itrs, err := influxql.Select(MustParseSelectStatement(`SELECT mean(value) FROM cpu WHERE time >= '1970-01-01T00:00:00Z' AND time < '1970-01-01T00:01:00Z' GROUP BY host, time(10s) fill(null)`), &ic)
@@ -488,12 +482,6 @@ func TestSelect_Fill_Null_Float(t *testing.T) {
 		{&influxql.FloatPoint{Name: "cpu", Tags: ParseTags("host=A"), Time: 30 * Second, Nil: true}},
 		{&influxql.FloatPoint{Name: "cpu", Tags: ParseTags("host=A"), Time: 40 * Second, Nil: true}},
 		{&influxql.FloatPoint{Name: "cpu", Tags: ParseTags("host=A"), Time: 50 * Second, Nil: true}},
-		{&influxql.FloatPoint{Name: "cpu", Tags: ParseTags("host=B"), Time: 0 * Second, Nil: true}},
-		{&influxql.FloatPoint{Name: "cpu", Tags: ParseTags("host=B"), Time: 10 * Second, Nil: true}},
-		{&influxql.FloatPoint{Name: "cpu", Tags: ParseTags("host=B"), Time: 20 * Second, Nil: true}},
-		{&influxql.FloatPoint{Name: "cpu", Tags: ParseTags("host=B"), Time: 30 * Second, Nil: true}},
-		{&influxql.FloatPoint{Name: "cpu", Tags: ParseTags("host=B"), Time: 40 * Second, Nil: true}},
-		{&influxql.FloatPoint{Name: "cpu", Tags: ParseTags("host=B"), Time: 50 * Second, Nil: true}},
 	}) {
 		t.Fatalf("unexpected points: %s", spew.Sdump(a))
 	}
@@ -507,12 +495,6 @@ func TestSelect_Fill_Number_Float(t *testing.T) {
 			{Name: "cpu", Tags: ParseTags("host=A"), Time: 12 * Second, Value: 2},
 		}}, nil
 	}
-	ic.SeriesKeysFn = func(opt influxql.IteratorOptions) (influxql.SeriesList, error) {
-		return influxql.SeriesList{
-			{Name: "cpu", Tags: ParseTags("host=A")},
-			{Name: "cpu", Tags: ParseTags("host=B")},
-		}, nil
-	}
 
 	// Execute selection.
 	itrs, err := influxql.Select(MustParseSelectStatement(`SELECT mean(value) FROM cpu WHERE time >= '1970-01-01T00:00:00Z' AND time < '1970-01-01T00:01:00Z' GROUP BY host, time(10s) fill(1)`), &ic)
@@ -525,12 +507,6 @@ func TestSelect_Fill_Number_Float(t *testing.T) {
 		{&influxql.FloatPoint{Name: "cpu", Tags: ParseTags("host=A"), Time: 30 * Second, Value: 1}},
 		{&influxql.FloatPoint{Name: "cpu", Tags: ParseTags("host=A"), Time: 40 * Second, Value: 1}},
 		{&influxql.FloatPoint{Name: "cpu", Tags: ParseTags("host=A"), Time: 50 * Second, Value: 1}},
-		{&influxql.FloatPoint{Name: "cpu", Tags: ParseTags("host=B"), Time: 0 * Second, Value: 1}},
-		{&influxql.FloatPoint{Name: "cpu", Tags: ParseTags("host=B"), Time: 10 * Second, Value: 1}},
-		{&influxql.FloatPoint{Name: "cpu", Tags: ParseTags("host=B"), Time: 20 * Second, Value: 1}},
-		{&influxql.FloatPoint{Name: "cpu", Tags: ParseTags("host=B"), Time: 30 * Second, Value: 1}},
-		{&influxql.FloatPoint{Name: "cpu", Tags: ParseTags("host=B"), Time: 40 * Second, Value: 1}},
-		{&influxql.FloatPoint{Name: "cpu", Tags: ParseTags("host=B"), Time: 50 * Second, Value: 1}},
 	}) {
 		t.Fatalf("unexpected points: %s", spew.Sdump(a))
 	}
@@ -544,12 +520,6 @@ func TestSelect_Fill_Previous_Float(t *testing.T) {
 			{Name: "cpu", Tags: ParseTags("host=A"), Time: 12 * Second, Value: 2},
 		}}, nil
 	}
-	ic.SeriesKeysFn = func(opt influxql.IteratorOptions) (influxql.SeriesList, error) {
-		return influxql.SeriesList{
-			{Name: "cpu", Tags: ParseTags("host=A")},
-			{Name: "cpu", Tags: ParseTags("host=B")},
-		}, nil
-	}
 
 	// Execute selection.
 	itrs, err := influxql.Select(MustParseSelectStatement(`SELECT mean(value) FROM cpu WHERE time >= '1970-01-01T00:00:00Z' AND time < '1970-01-01T00:01:00Z' GROUP BY host, time(10s) fill(previous)`), &ic)
@@ -562,12 +532,6 @@ func TestSelect_Fill_Previous_Float(t *testing.T) {
 		{&influxql.FloatPoint{Name: "cpu", Tags: ParseTags("host=A"), Time: 30 * Second, Value: 2}},
 		{&influxql.FloatPoint{Name: "cpu", Tags: ParseTags("host=A"), Time: 40 * Second, Value: 2}},
 		{&influxql.FloatPoint{Name: "cpu", Tags: ParseTags("host=A"), Time: 50 * Second, Value: 2}},
-		{&influxql.FloatPoint{Name: "cpu", Tags: ParseTags("host=B"), Time: 0 * Second, Value: 2}},
-		{&influxql.FloatPoint{Name: "cpu", Tags: ParseTags("host=B"), Time: 10 * Second, Value: 2}},
-		{&influxql.FloatPoint{Name: "cpu", Tags: ParseTags("host=B"), Time: 20 * Second, Value: 2}},
-		{&influxql.FloatPoint{Name: "cpu", Tags: ParseTags("host=B"), Time: 30 * Second, Value: 2}},
-		{&influxql.FloatPoint{Name: "cpu", Tags: ParseTags("host=B"), Time: 40 * Second, Value: 2}},
-		{&influxql.FloatPoint{Name: "cpu", Tags: ParseTags("host=B"), Time: 50 * Second, Value: 2}},
 	}) {
 		t.Fatalf("unexpected points: %s", spew.Sdump(a))
 	}


### PR DESCRIPTION
If a name/tag combination does not have any points in the time range at
all, fill will not generate points for it.
