### PR TITLE
Fix go vet issues on 1.4

### DIFF
--- a/influxql/ast_test.go
+++ b/influxql/ast_test.go
@@ -1136,14 +1136,14 @@ func Test_fieldsNames(t *testing.T) {
 }
 
 func TestSources_Names(t *testing.T) {
-	sources := influxql.Sources{
+	sources := influxql.Sources([]influxql.Source{
 		&influxql.Measurement{
 			Name: "cpu",
 		},
 		&influxql.Measurement{
 			Name: "mem",
 		},
-	}
+	})
 
 	names := sources.Names()
 	if names[0] != "cpu" {
@@ -1155,22 +1155,22 @@ func TestSources_Names(t *testing.T) {
 }
 
 func TestSources_HasSystemSource(t *testing.T) {
-	sources := influxql.Sources{
+	sources := influxql.Sources([]influxql.Source{
 		&influxql.Measurement{
 			Name: "_measurements",
 		},
-	}
+	})
 
 	ok := sources.HasSystemSource()
 	if !ok {
 		t.Errorf("expected to find a system source, found none")
 	}
 
-	sources = influxql.Sources{
+	sources = influxql.Sources([]influxql.Source{
 		&influxql.Measurement{
 			Name: "cpu",
 		},
-	}
+	})
 
 	ok = sources.HasSystemSource()
 	if ok {

--- a/influxql/iterator_test.go
+++ b/influxql/iterator_test.go
@@ -610,7 +610,7 @@ func TestFloatAuxIterator(t *testing.T) {
 			{Time: 0, Value: 1, Aux: []interface{}{float64(100), float64(200)}},
 			{Time: 1, Value: 2, Aux: []interface{}{float64(500), math.NaN()}},
 		}},
-		influxql.SeriesList{
+		[]influxql.Series{
 			{Aux: []influxql.DataType{influxql.Float, influxql.Float}},
 		},
 		influxql.IteratorOptions{Aux: []string{"f0", "f1"}},

--- a/tsdb/meta_test.go
+++ b/tsdb/meta_test.go
@@ -11,9 +11,9 @@ import (
 
 // Test comparing SeriesIDs for equality.
 func Test_SeriesIDs_Equals(t *testing.T) {
-	ids1 := tsdb.SeriesIDs{1, 2, 3}
-	ids2 := tsdb.SeriesIDs{1, 2, 3}
-	ids3 := tsdb.SeriesIDs{4, 5, 6}
+	ids1 := tsdb.SeriesIDs([]uint64{1, 2, 3})
+	ids2 := tsdb.SeriesIDs([]uint64{1, 2, 3})
+	ids3 := tsdb.SeriesIDs([]uint64{4, 5, 6})
 
 	if !ids1.Equals(ids2) {
 		t.Fatal("expected ids1 == ids2")
@@ -25,9 +25,9 @@ func Test_SeriesIDs_Equals(t *testing.T) {
 // Test intersecting sets of SeriesIDs.
 func Test_SeriesIDs_Intersect(t *testing.T) {
 	// Test swaping l & r, all branches of if-else, and exit loop when 'j < len(r)'
-	ids1 := tsdb.SeriesIDs{1, 3, 4, 5, 6}
-	ids2 := tsdb.SeriesIDs{1, 2, 3, 7}
-	exp := tsdb.SeriesIDs{1, 3}
+	ids1 := tsdb.SeriesIDs([]uint64{1, 3, 4, 5, 6})
+	ids2 := tsdb.SeriesIDs([]uint64{1, 2, 3, 7})
+	exp := tsdb.SeriesIDs([]uint64{1, 3})
 	got := ids1.Intersect(ids2)
 
 	if !exp.Equals(got) {
@@ -35,9 +35,9 @@ func Test_SeriesIDs_Intersect(t *testing.T) {
 	}
 
 	// Test exit for loop when 'i < len(l)'
-	ids1 = tsdb.SeriesIDs{1}
-	ids2 = tsdb.SeriesIDs{1, 2}
-	exp = tsdb.SeriesIDs{1}
+	ids1 = tsdb.SeriesIDs([]uint64{1})
+	ids2 = tsdb.SeriesIDs([]uint64{1, 2})
+	exp = tsdb.SeriesIDs([]uint64{1})
 	got = ids1.Intersect(ids2)
 
 	if !exp.Equals(got) {
@@ -48,9 +48,9 @@ func Test_SeriesIDs_Intersect(t *testing.T) {
 // Test union sets of SeriesIDs.
 func Test_SeriesIDs_Union(t *testing.T) {
 	// Test all branches of if-else, exit loop because of 'j < len(r)', and append remainder from left.
-	ids1 := tsdb.SeriesIDs{1, 2, 3, 7}
-	ids2 := tsdb.SeriesIDs{1, 3, 4, 5, 6}
-	exp := tsdb.SeriesIDs{1, 2, 3, 4, 5, 6, 7}
+	ids1 := tsdb.SeriesIDs([]uint64{1, 2, 3, 7})
+	ids2 := tsdb.SeriesIDs([]uint64{1, 3, 4, 5, 6})
+	exp := tsdb.SeriesIDs([]uint64{1, 2, 3, 4, 5, 6, 7})
 	got := ids1.Union(ids2)
 
 	if !exp.Equals(got) {
@@ -58,9 +58,9 @@ func Test_SeriesIDs_Union(t *testing.T) {
 	}
 
 	// Test exit because of 'i < len(l)' and append remainder from right.
-	ids1 = tsdb.SeriesIDs{1}
-	ids2 = tsdb.SeriesIDs{1, 2}
-	exp = tsdb.SeriesIDs{1, 2}
+	ids1 = tsdb.SeriesIDs([]uint64{1})
+	ids2 = tsdb.SeriesIDs([]uint64{1, 2})
+	exp = tsdb.SeriesIDs([]uint64{1, 2})
 	got = ids1.Union(ids2)
 
 	if !exp.Equals(got) {
@@ -71,9 +71,9 @@ func Test_SeriesIDs_Union(t *testing.T) {
 // Test removing one set of SeriesIDs from another.
 func Test_SeriesIDs_Reject(t *testing.T) {
 	// Test all branches of if-else, exit loop because of 'j < len(r)', and append remainder from left.
-	ids1 := tsdb.SeriesIDs{1, 2, 3, 7}
-	ids2 := tsdb.SeriesIDs{1, 3, 4, 5, 6}
-	exp := tsdb.SeriesIDs{2, 7}
+	ids1 := tsdb.SeriesIDs([]uint64{1, 2, 3, 7})
+	ids2 := tsdb.SeriesIDs([]uint64{1, 3, 4, 5, 6})
+	exp := tsdb.SeriesIDs([]uint64{2, 7})
 	got := ids1.Reject(ids2)
 
 	if !exp.Equals(got) {
@@ -81,8 +81,8 @@ func Test_SeriesIDs_Reject(t *testing.T) {
 	}
 
 	// Test exit because of 'i < len(l)'.
-	ids1 = tsdb.SeriesIDs{1}
-	ids2 = tsdb.SeriesIDs{1, 2}
+	ids1 = tsdb.SeriesIDs([]uint64{1})
+	ids2 = tsdb.SeriesIDs([]uint64{1, 2})
 	exp = tsdb.SeriesIDs{}
 	got = ids1.Reject(ids2)
 

--- a/tsdb/query_executor.go
+++ b/tsdb/query_executor.go
@@ -564,12 +564,12 @@ func (q *QueryExecutor) planShowMeasurements(stmt *influxql.ShowMeasurementsStat
 	}
 
 	ss := &influxql.SelectStatement{
-		Fields: influxql.Fields{
+		Fields: influxql.Fields([]*influxql.Field{
 			{Expr: &influxql.VarRef{Val: "name"}},
-		},
-		Sources: influxql.Sources{
+		}),
+		Sources: influxql.Sources([]influxql.Source{
 			&influxql.Measurement{Name: "_measurements"},
-		},
+		}),
 		Condition:  condition,
 		Offset:     stmt.Offset,
 		Limit:      stmt.Limit,
@@ -621,10 +621,10 @@ func (q *QueryExecutor) planShowTagKeys(stmt *influxql.ShowTagKeysStatement, dat
 	}
 
 	ss := &influxql.SelectStatement{
-		Fields: influxql.Fields{
+		Fields: []*influxql.Field{
 			{Expr: &influxql.VarRef{Val: "tagKey"}},
 		},
-		Sources: influxql.Sources{
+		Sources: []influxql.Source{
 			&influxql.Measurement{Name: "_tagKeys"},
 		},
 		Condition:  condition,

--- a/tsdb/query_executor_test.go
+++ b/tsdb/query_executor_test.go
@@ -33,7 +33,7 @@ cpu,region=serverB value=3 20
 
 	e := NewQueryExecutor()
 	e.MetaClient.ShardIDsByTimeRangeFn = func(sources influxql.Sources, tmin, tmax time.Time) (a []uint64, err error) {
-		if !reflect.DeepEqual(sources, influxql.Sources{&influxql.Measurement{Database: "db0", RetentionPolicy: "rp0", Name: "cpu"}}) {
+		if !reflect.DeepEqual(sources, influxql.Sources([]influxql.Source{&influxql.Measurement{Database: "db0", RetentionPolicy: "rp0", Name: "cpu"}})) {
 			t.Fatalf("unexpected sources: %s", spew.Sdump(sources))
 		} else if tmin.IsZero() {
 			t.Fatalf("unexpected tmin: %s", tmin)

--- a/tsdb/shard.go
+++ b/tsdb/shard.go
@@ -491,7 +491,7 @@ func (a Shards) SeriesKeys(opt influxql.IteratorOptions) (influxql.SeriesList, e
 			return nil, errors.New("cannot select from multiple system sources")
 		}
 		// Meta queries don't need to know the series name and always have a single string.
-		return influxql.SeriesList{{Aux: []influxql.DataType{influxql.String}}}, nil
+		return []influxql.Series{{Aux: []influxql.DataType{influxql.String}}}, nil
 	}
 
 	seriesMap := make(map[string]influxql.Series)


### PR DESCRIPTION
go 1.5 was being used to develop the query engine branch, but we aren't
using 1.5 for master at the moment. This fixes issues that go vet brings
up in 1.4 that don't exist in 1.5.
