### PR TITLE
Improve performance of LIMIT with no dimensions

### DIFF
--- a/influxql/iterator.gen.go
+++ b/influxql/iterator.gen.go
@@ -403,6 +403,10 @@ func (itr *floatLimitIterator) Next() *FloatPoint {
 
 		// Read next point if we're beyond the limit.
 		if itr.opt.Limit > 0 && (itr.n-itr.opt.Offset) > itr.opt.Limit {
+			// If there's no interval and no groups then simply exit.
+			if itr.opt.Interval.IsZero() && len(itr.opt.Dimensions) == 0 {
+				return nil
+			}
 			continue
 		}
 
@@ -1294,6 +1298,10 @@ func (itr *integerLimitIterator) Next() *IntegerPoint {
 
 		// Read next point if we're beyond the limit.
 		if itr.opt.Limit > 0 && (itr.n-itr.opt.Offset) > itr.opt.Limit {
+			// If there's no interval and no groups then simply exit.
+			if itr.opt.Interval.IsZero() && len(itr.opt.Dimensions) == 0 {
+				return nil
+			}
 			continue
 		}
 
@@ -2185,6 +2193,10 @@ func (itr *stringLimitIterator) Next() *StringPoint {
 
 		// Read next point if we're beyond the limit.
 		if itr.opt.Limit > 0 && (itr.n-itr.opt.Offset) > itr.opt.Limit {
+			// If there's no interval and no groups then simply exit.
+			if itr.opt.Interval.IsZero() && len(itr.opt.Dimensions) == 0 {
+				return nil
+			}
 			continue
 		}
 
@@ -3076,6 +3088,10 @@ func (itr *booleanLimitIterator) Next() *BooleanPoint {
 
 		// Read next point if we're beyond the limit.
 		if itr.opt.Limit > 0 && (itr.n-itr.opt.Offset) > itr.opt.Limit {
+			// If there's no interval and no groups then simply exit.
+			if itr.opt.Interval.IsZero() && len(itr.opt.Dimensions) == 0 {
+				return nil
+			}
 			continue
 		}
 

--- a/influxql/iterator.gen.go.tmpl
+++ b/influxql/iterator.gen.go.tmpl
@@ -405,6 +405,10 @@ func (itr *{{.name}}LimitIterator) Next() *{{.Name}}Point {
 
 		// Read next point if we're beyond the limit.
 		if itr.opt.Limit > 0 && (itr.n-itr.opt.Offset) > itr.opt.Limit {
+			// If there's no interval and no groups then simply exit.
+			if itr.opt.Interval.IsZero() && len(itr.opt.Dimensions) == 0 {
+				return nil
+			}
 			continue
 		}
 

--- a/influxql/iterator_test.go
+++ b/influxql/iterator_test.go
@@ -512,7 +512,6 @@ func TestLimitIterator_Float(t *testing.T) {
 
 	if a := Iterators([]influxql.Iterator{itr}).ReadAll(); !deep.Equal(a, [][]influxql.Point{
 		{&influxql.FloatPoint{Name: "cpu", Time: 5, Value: 3}},
-		{&influxql.FloatPoint{Name: "mem", Time: 7, Value: 8}},
 	}) {
 		t.Fatalf("unexpected points: %s", spew.Sdump(a))
 	}
@@ -539,7 +538,6 @@ func TestLimitIterator_Integer(t *testing.T) {
 
 	if a := Iterators([]influxql.Iterator{itr}).ReadAll(); !deep.Equal(a, [][]influxql.Point{
 		{&influxql.IntegerPoint{Name: "cpu", Time: 5, Value: 3}},
-		{&influxql.IntegerPoint{Name: "mem", Time: 7, Value: 8}},
 	}) {
 		t.Fatalf("unexpected points: %s", spew.Sdump(a))
 	}
@@ -566,7 +564,6 @@ func TestLimitIterator_String(t *testing.T) {
 
 	if a := Iterators([]influxql.Iterator{itr}).ReadAll(); !deep.Equal(a, [][]influxql.Point{
 		{&influxql.StringPoint{Name: "cpu", Time: 5, Value: "b"}},
-		{&influxql.StringPoint{Name: "mem", Time: 7, Value: "e"}},
 	}) {
 		t.Fatalf("unexpected points: %s", spew.Sdump(a))
 	}
@@ -593,7 +590,6 @@ func TestLimitIterator_Boolean(t *testing.T) {
 
 	if a := Iterators([]influxql.Iterator{itr}).ReadAll(); !deep.Equal(a, [][]influxql.Point{
 		{&influxql.BooleanPoint{Name: "cpu", Time: 5, Value: false}},
-		{&influxql.BooleanPoint{Name: "mem", Time: 7, Value: true}},
 	}) {
 		t.Fatalf("unexpected points: %s", spew.Sdump(a))
 	}


### PR DESCRIPTION
## Overview

Previously the `LimitIterator` continued to read through all points even when there were no dimensions. This pull request changes it so that if no dimensions are specified then it returns immediately. 
### Results

```
Series: 100,000
Pts/Series: 100
Query: SELECT * FROM cpu LIMIT 1
```

Previous: `30s`
New: `2.6s - 3s`
